### PR TITLE
Renaming all relevant namespaces to FSharp.Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ to be used as a quick ref.
 module TaskSeq =
     open System.Collections.Generic
     open System.Threading.Tasks
-    open FSharpy.TaskSeqBuilders
+    open FSharp.Control.TaskSeqBuilders
 
     /// Initialize an empty taskSeq.
     val empty<'T> : taskSeq<'T>

--- a/src/FSharpy.TaskSeq.Test/AssemblyInfo.fs
+++ b/src/FSharpy.TaskSeq.Test/AssemblyInfo.fs
@@ -1,4 +1,4 @@
-namespace FSharpy.Tests
+namespace TaskSeq.Tests
 
 open System.Runtime.CompilerServices
 

--- a/src/FSharpy.TaskSeq.Test/Nunit.Extensions.fs
+++ b/src/FSharpy.TaskSeq.Test/Nunit.Extensions.fs
@@ -1,4 +1,4 @@
-namespace FSharpy.Tests
+namespace TaskSeq.Tests
 
 open System
 open System.Threading.Tasks

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Cast.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Cast.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Cast
+module TaskSeq.Tests.Cast
 
 open System
 
@@ -6,7 +6,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.box

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Choose
+module TaskSeq.Tests.Choose
 
 open System
 open System.Threading.Tasks
@@ -7,7 +7,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.map

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.Collect
+module TaskSeq.Tests.Collect
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.collect

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Concat.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Concat.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Concat
+module TaskSeq.Tests.Concat
 
 open System
 
@@ -6,7 +6,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 open System.Collections.Generic
 
 //

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Contains.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Contains.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.Contains
+module TaskSeq.Tests.Contains
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.contains

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Empty.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Empty.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Empty
+module TaskSeq.Tests.Empty
 
 open System.Threading.Tasks
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 
 [<Fact>]

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.ExactlyOne
+module TaskSeq.Tests.ExactlyOne
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.exactlyOne

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Exists.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Exists.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.Exists
+module TaskSeq.Tests.Exists
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.exists

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Filter
+module TaskSeq.Tests.Filter
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.filter

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.Find
+module TaskSeq.Tests.Find
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 open System.Collections.Generic
 
 //

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.FindIndex.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.FindIndex.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.FindIndex
+module TaskSeq.Tests.FindIndex
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 open System.Collections.Generic
 
 //

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Fold
+module TaskSeq.Tests.Fold
 
 open System.Text
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.fold

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Head
+module TaskSeq.Tests.Head
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.head

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Indexed.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Indexed.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.Indexed
+module TaskSeq.Tests.Indexed
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.indexed

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Init.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Init.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Init
+module TaskSeq.Tests.Init
 
 open System
 
@@ -6,7 +6,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.init

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.IsEmpty.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.IsEmpty.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.IsEmpty
+module TaskSeq.Tests.IsEmpty
 
 open System.Threading.Tasks
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 module EmptySeq =
 

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Item
+module TaskSeq.Tests.Item
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.item

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -1,9 +1,9 @@
-module FSharpy.Tests.Iter
+module TaskSeq.Tests.Iter
 
 open Xunit
 open FsUnit.Xunit
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.iter

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Last
+module TaskSeq.Tests.Last
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.last

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Length
+module TaskSeq.Tests.Length
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.length

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.Map
+module TaskSeq.Tests.Map
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.map

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.``Conversion-From``
+module TaskSeq.Tests.``Conversion-From``
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 let validateSequence sq =
     TaskSeq.toArrayAsync sq

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Pick.Tests.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.Pick
+module TaskSeq.Tests.Pick
 
 open System
 open System.Collections.Generic
@@ -6,7 +6,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 
 //

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.PocTests.fs
@@ -1,10 +1,10 @@
-namespace FSharpy.Tests
+namespace TaskSeq.Tests
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 /////////////////////////////////////////////////////////////////////////////
 ///                                                                       ///

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Realworld.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Realworld.fs
@@ -1,4 +1,4 @@
-namespace FSharpy.Tests
+namespace TaskSeq.Tests
 
 open System
 open System.IO
@@ -6,7 +6,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 open System.Threading.Tasks
 open System.Diagnostics
 open System.Collections.Generic

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug-delayed.Tests.CE.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Bug #42 -- asynchronous`` // see PR #42
+module TaskSeq.Tests.``Bug #42 -- asynchronous`` // see PR #42
 
 open System
 open System.Threading.Tasks
@@ -9,7 +9,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 // Module contains same tests as its previous file
 // except that each item is delayed randomly to force

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.StateTransitionBug.Tests.CE.fs
@@ -1,4 +1,4 @@
-module FSharpy.Tests.``Bug #42 -- synchronous`` // see PR #42
+module TaskSeq.Tests.``Bug #42 -- synchronous`` // see PR #42
 
 open System
 open System.Threading.Tasks
@@ -9,7 +9,7 @@ open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 [<Fact>]
 let ``CE empty taskSeq with MoveNextAsync -- untyped`` () = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.``taskSeq Computation Expression``
+module TaskSeq.Tests.``taskSeq Computation Expression``
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 [<Fact>]
 let ``CE taskSeq with several yield!`` () = task {

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.ToXXX.Tests.fs
@@ -1,10 +1,10 @@
-module FSharpy.Tests.``Conversion-To``
+module TaskSeq.Tests.``Conversion-To``
 
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 open System.Collections.Generic
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharpy.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -1,11 +1,11 @@
-module FSharpy.Tests.Zip
+module TaskSeq.Tests.Zip
 
 open System
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 
 //
 // TaskSeq.zip

--- a/src/FSharpy.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharpy.TaskSeq.Test/TestUtils.fs
@@ -1,4 +1,4 @@
-namespace FSharpy.Tests
+namespace TaskSeq.Tests
 
 open System
 open System.Threading
@@ -7,7 +7,7 @@ open System.Diagnostics
 
 open FsToolkit.ErrorHandling
 
-open FSharpy
+open FSharp.Control
 open System.Collections.Generic
 open FsUnit.Xunit
 open Xunit

--- a/src/FSharpy.TaskSeq/TaskSeq.fs
+++ b/src/FSharpy.TaskSeq/TaskSeq.fs
@@ -1,4 +1,4 @@
-namespace FSharpy
+namespace FSharp.Control
 
 open System.Collections.Generic
 open System.Threading
@@ -6,7 +6,7 @@ open System.Threading.Tasks
 
 module TaskSeq =
     // F# BUG: the following module is 'AutoOpen' and this isn't needed in the Tests project. Why do we need to open it?
-    open FSharpy.TaskSeqBuilders
+    open FSharp.Control.TaskSeqBuilders
 
     // Just for convenience
     module Internal = TaskSeqInternal

--- a/src/FSharpy.TaskSeq/TaskSeq.fsi
+++ b/src/FSharpy.TaskSeq/TaskSeq.fsi
@@ -1,9 +1,9 @@
-namespace FSharpy
+namespace FSharp.Control
 
 module TaskSeq =
     open System.Collections.Generic
     open System.Threading.Tasks
-    open FSharpy.TaskSeqBuilders
+    open FSharp.Control.TaskSeqBuilders
 
     /// Initialize an empty taskSeq.
     val empty<'T> : taskSeq<'T>

--- a/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqBuilder.fs
@@ -1,4 +1,4 @@
-namespace FSharpy.TaskSeqBuilders
+namespace FSharp.Control.TaskSeqBuilders
 
 open System.Diagnostics
 

--- a/src/FSharpy.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharpy.TaskSeq/TaskSeqInternal.fs
@@ -1,10 +1,10 @@
-namespace FSharpy
+namespace FSharp.Control
 
 open System
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
-open FSharpy.TaskSeqBuilders
+open FSharp.Control.TaskSeqBuilders
 
 [<AutoOpen>]
 module ExtraTaskSeqOperators =

--- a/src/FSharpy.TaskSeq/Utils.fs
+++ b/src/FSharpy.TaskSeq/Utils.fs
@@ -1,4 +1,4 @@
-namespace FSharpy
+namespace FSharp.Control
 
 open System.Threading.Tasks
 


### PR DESCRIPTION
As per #71. Won't close that issue just yet, in a follow-up PR I'll rename the assembly filenames and source filenames as well.