### PR TITLE
Fix permissions for running test reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,11 @@ name: ci-test
 
 on: [pull_request]
 
+permissions:
+  id-token: write
+  contents: read
+  checks: write
+
 jobs:
   test-release:
     name: Test Release Build


### PR DESCRIPTION
PRs through forks show "Resource not accessible by integration" error in the CI logs. According to https://github.com/dorny/test-reporter/issues/149, this is a permissions issue.