### PR TITLE
Task seq builder using bug

### DIFF
--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="TaskSeq.Realworld.fs" />
     <Compile Include="TaskSeq.AsyncExtensions.Tests.fs" />
     <Compile Include="TaskSeq.TaskExtensions.Tests.fs" />
+    <Compile Include="TaskSeq.Using.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
@@ -1,0 +1,97 @@
+module FSharp.Control.TaskSeq.Test
+
+open System
+open System.Threading.Tasks
+open FSharp.Control
+open FsUnit
+open Xunit
+
+
+type private OneGetter() =
+    member _.Get1() = 1
+
+type private Disposable() =
+    inherit OneGetter()
+
+    interface IDisposable with
+        member _.Dispose() = ()
+
+type private AsyncDisposable() =
+    inherit OneGetter()
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() = ValueTask()
+
+type private MultiDispose() =
+    inherit OneGetter()
+
+    interface IDisposable with
+        member _.Dispose() =
+            ()
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() =
+            ValueTask()
+
+let private check ts = task {
+    let! length = ts |> TaskSeq.length
+    length |> should equal 1
+}
+
+[<Fact>]
+let ``CE task: Using when type implements IDisposable``() =
+    let ts = taskSeq {
+        use x = new Disposable()
+
+        yield x.Get1()
+    }
+
+    check ts
+
+[<Fact>]
+let ``CE task: Using when type implements IAsyncDisposable``() =
+    let ts = taskSeq {
+        use x = AsyncDisposable()
+        yield x.Get1()
+    }
+
+    check ts
+
+
+[<Fact>]
+let ``CE task: Using when type implements IDisposable and IAsyncDisposable``() =
+    let ts = taskSeq {
+        use x = new MultiDispose()
+        yield x.Get1()
+    }
+
+    check ts
+
+[<Fact>]
+let ``CE task: Using! when type implements IDisposable``() =
+    let ts = taskSeq {
+        use! x = task { return new Disposable() }
+        yield x.Get1()
+    }
+
+    check ts
+
+
+[<Fact>]
+let ``CE task: Using! when type implements IAsyncDisposable``() =
+    let ts = taskSeq {
+        use! x = task { return AsyncDisposable() }
+        yield x.Get1()
+    }
+
+    check ts
+
+
+[<Fact>]
+let ``CE task: Using! when type implements IDisposable and IAsyncDisposable``() =
+    let ts = taskSeq {
+        use! x = task { return new MultiDispose() }
+        yield x.Get1()
+    }
+
+    check ts

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
@@ -26,10 +26,10 @@ type private MultiDispose(disposed: int ref) =
     inherit OneGetter()
 
     interface IDisposable with
-        member _.Dispose() = disposed.Value <- !disposed + 1
+        member _.Dispose() = disposed.Value <- 1
 
     interface IAsyncDisposable with
-        member _.DisposeAsync() = ValueTask(task { do disposed.Value <- !disposed + 1 })
+        member _.DisposeAsync() = ValueTask(task { do disposed.Value <- -1 })
 
 let private check = TaskSeq.length >> Task.map (should equal 1)
 
@@ -67,7 +67,7 @@ let ``CE task: Using when type implements IDisposable and IAsyncDisposable`` () 
     }
 
     check ts
-    |> Task.map (fun _ -> disposed.Value |> should equal 1) // only one of the two dispose method should fire
+    |> Task.map (fun _ -> disposed.Value |> should equal -1) // should prefer IAsyncDisposable, which returns -1
 
 [<Fact>]
 let ``CE task: Using! when type implements IDisposable`` () =
@@ -103,4 +103,4 @@ let ``CE task: Using! when type implements IDisposable and IAsyncDisposable`` ()
     }
 
     check ts
-    |> Task.map (fun _ -> disposed.Value |> should equal 1) // only one of the two dispose method should fire
+    |> Task.map (fun _ -> disposed.Value |> should equal -1) // should prefer IAsyncDisposable, which returns -1

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
@@ -61,7 +61,7 @@ let ``CE task: Using when type implements IAsyncDisposable``() =
 [<Fact>]
 let ``CE task: Using when type implements IDisposable and IAsyncDisposable``() =
     let ts = taskSeq {
-        use x = new MultiDispose()
+        use x = new MultiDispose() // Fails to compile
         yield x.Get1()
     }
 
@@ -90,7 +90,7 @@ let ``CE task: Using! when type implements IAsyncDisposable``() =
 [<Fact>]
 let ``CE task: Using! when type implements IDisposable and IAsyncDisposable``() =
     let ts = taskSeq {
-        use! x = task { return new MultiDispose() }
+        use! x = task { return new MultiDispose() } // Fails to compile
         yield x.Get1()
     }
 

--- a/src/FSharp.Control.TaskSeq/AsyncExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/AsyncExtensions.fs
@@ -1,7 +1,5 @@
 namespace FSharp.Control
 
-open FSharp.Control.TaskSeqBuilders
-
 [<AutoOpen>]
 module AsyncExtensions =
 

--- a/src/FSharp.Control.TaskSeq/AsyncExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/AsyncExtensions.fsi
@@ -2,7 +2,6 @@ namespace FSharp.Control
 
 [<AutoOpen>]
 module AsyncExtensions =
-    open FSharp.Control.TaskSeqBuilders
 
     type AsyncBuilder with
 

--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -24,10 +24,11 @@ Generates optimized IL code through the new resumable state machines, and comes 
     <PackageReleaseNotes>
       Release notes:
       0.3.0 (unreleased)
-       - adds support for 'for .. in ..' with task sequences in F# tasks and async, #75, #93 and #99 (with help from @theangrybyrd)
-       - adds TaskSeq.singleton, #90 (by @gusty)
-       - improves TaskSeq.empty by not relying on resumable state, #89 (by @gusty)
-       - does not throw exceptions anymore for unequal lengths in TaskSeq.zip, fixes #32
+       - adds support for 'for .. in ..' with task sequences in F# tasks and async, #75, #93 and #99 (with help from @theangrybyrd).
+       - adds TaskSeq.singleton, #90 (by @gusty).
+       - fixes overload resolution bug with 'use' and 'use!', #97 (thanks @peterfaria).
+       - improves TaskSeq.empty by not relying on resumable state, #89 (by @gusty).
+       - does not throw exceptions anymore for unequal lengths in TaskSeq.zip, fixes #32.
       0.2.2
        - removes TaskSeq.toSeqCachedAsync, which was incorrectly named. Use toSeq or toListAsync instead.
        - renames TaskSeq.toSeqCached to TaskSeq.toSeq, which was its actual operational behavior.

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fs
@@ -7,8 +7,6 @@ open System.Threading.Tasks
 open Microsoft.FSharp.Core.CompilerServices
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 
-open FSharp.Control.TaskSeqBuilders
-
 #nowarn "57"
 #nowarn "1204"
 #nowarn "3513"

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
@@ -4,7 +4,6 @@ namespace FSharp.Control
 
 [<AutoOpen>]
 module TaskExtensions =
-    open FSharp.Control.TaskSeqBuilders
 
     type TaskBuilder with
 

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -7,8 +7,6 @@ open System.Threading.Tasks
 #nowarn "57"
 
 module TaskSeq =
-    // F# BUG: the following module is 'AutoOpen' and this isn't needed in the Tests project. Why do we need to open it?
-    open FSharp.Control.TaskSeqBuilders
 
     // Just for convenience
     module Internal = TaskSeqInternal

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -5,7 +5,6 @@ namespace FSharp.Control
 module TaskSeq =
     open System.Collections.Generic
     open System.Threading.Tasks
-    open FSharp.Control.TaskSeqBuilders
 
     /// Initialize an empty taskSeq.
     val empty<'T> : taskSeq<'T>

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -4,7 +4,6 @@ open System
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
-open FSharp.Control.TaskSeqBuilders
 
 [<AutoOpen>]
 module ExtraTaskSeqOperators =


### PR DESCRIPTION
Fixes: #97

When a type implements both `IDisposable` and `IAsyncDisposable`,
F# cannot determine which overload of `TaskSeqBuilder.Using` to use.