### PR TITLE
Remove `invalidArg` exception from `TaskSeq.zip`

### DIFF
--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -132,32 +132,3 @@ module Other =
 
         combined |> should equal [| ("one", 42L); ("two", 43L) |]
     }
-
-    [<Theory; InlineData true; InlineData false>]
-    let ``TaskSeq-zip throws on unequal lengths, variant`` leftThrows = task {
-        let long = Gen.sideEffectTaskSeq 11
-        let short = Gen.sideEffectTaskSeq 10
-
-        let combined =
-            if leftThrows then
-                TaskSeq.zip short long
-            else
-                TaskSeq.zip long short
-
-        fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
-        |> should throwAsyncExact typeof<ArgumentException>
-    }
-
-    [<Theory; InlineData true; InlineData false>]
-    let ``TaskSeq-zip throws on unequal lengths with empty seq`` leftThrows = task {
-        let one = Gen.sideEffectTaskSeq 1
-
-        let combined =
-            if leftThrows then
-                TaskSeq.zip TaskSeq.empty one
-            else
-                TaskSeq.zip one TaskSeq.empty
-
-        fun () -> TaskSeq.toArrayAsync combined |> Task.ignore
-        |> should throwAsyncExact typeof<ArgumentException>
-    }

--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -23,6 +23,8 @@ Generates optimized IL code through the new resumable state machines, and comes 
     <PackageReadmeFile>nuget-package-readme.md</PackageReadmeFile>
     <PackageReleaseNotes>
       Release notes:
+      0.2.3
+       - do not throw exception for unequal lengths in TaskSeq.zip, fixes #32
       0.2.2
        - removes TaskSeq.toSeqCachedAsync, which was incorrectly named. Use toSeq or toListAsync instead.
        - renames TaskSeq.toSeqCached to TaskSeq.toSeq, which was its actual operational behavior.

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -272,28 +272,17 @@ module internal TaskSeqInternal =
           }
 
     let zip (source1: taskSeq<_>) (source2: taskSeq<_>) = taskSeq {
-        let inline validate step1 step2 =
-            if step1 <> step2 then
-                if step1 then
-                    invalidArg "taskSequence1" "The task sequences have different lengths."
-
-                if step2 then
-                    invalidArg "taskSequence2" "The task sequences have different lengths."
-
-
         use e1 = source1.GetAsyncEnumerator(CancellationToken())
         use e2 = source2.GetAsyncEnumerator(CancellationToken())
         let mutable go = true
         let! step1 = e1.MoveNextAsync()
         let! step2 = e2.MoveNextAsync()
         go <- step1 && step2
-        validate step1 step2
 
         while go do
             yield e1.Current, e2.Current
             let! step1 = e1.MoveNextAsync()
             let! step2 = e2.MoveNextAsync()
-            validate step1 step2
             go <- step1 && step2
     }
 


### PR DESCRIPTION
Fixes: #32 

This is technically a backward incompatible change, but we're still in 0.x, so let's just go with it.