### PR TITLE
Test wrongly successful build steps in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,4 +17,7 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet build (release)
+        # see issue #105
+        # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
+        shell: cmd
         run: ./build.cmd

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet build (release)
+        # see issue #105
+        # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
+        shell: cmd
         run: ./build.cmd
 
   test-release:
@@ -36,6 +39,9 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it
       - name: Run dotnet test - release
+        # see issue #105
+        # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
+        shell: cmd
         run: ./build.cmd ci -release
       - name: Publish test results - release
         uses: dorny/test-reporter@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-dotnet@v3
       # build it, test it, pack it, publish it
       - name: Run dotnet build (release, for nuget)
+        # see issue #105
+        # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
         run: ./build.cmd
       - name: Nuget publish
         # skip-duplicate ensures that the 409 error received when the package was already published,

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: dorny/test-reporter@v1
       with:
         artifact: test-results-release    # artifact name
-        name: Report release tests         # Name of the check run which will be created
+        name: Report release tests        # Name of the check run which will be created
         path: '*.trx'                     # Path to test results (inside artifact .zip)
         reporter: dotnet-trx              # Format of test results
 
@@ -26,6 +26,6 @@ jobs:
     - uses: dorny/test-reporter@v1
       with:
         artifact: test-results-debug      # artifact name
-        name: Report debug tests           # Name of the check run which will be created
+        name: Report debug tests          # Name of the check run which will be created
         path: '*.trx'                     # Path to test results (inside artifact .zip)
         reporter: dotnet-trx              # Format of test results

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,9 @@ jobs:
 
       # build it, test it
       - name: Run dotnet test - release
+        # see issue #105
+        # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
+        shell: cmd 
         run: ./build.cmd ci -release
 
       # upload test results
@@ -46,6 +49,9 @@ jobs:
 
       # build it, test it
       - name: Run dotnet test - debug
+        # see issue #105
+        # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
+        shell: cmd
         run: ./build.cmd ci -debug
 
       # upload test results


### PR DESCRIPTION
It turned out that the CI steps incorrectly returns `success`. Running `build.cmd` in a default CI Github workflow leads to the `%ERRORLEVEL%` being swallowed, which is a result of the default shell on Windows being PowerShell Core. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell for more info.

Solution: use `shell: cmd` in the steps that require proper handling of Windows command scripts.

Also, [see this SO question](https://stackoverflow.com/questions/70652006/how-to-capture-the-batch-script-error-during-a-run-in-github-actions-workflow/74567003#74567003).

Before rewriting the history in this PR, there were numerous attempts at fixing this, using a deliberately failing (compile error) build, which kept showing up as green (success). Squashed all those bits for readability.