### PR TITLE
Support all `^TaskLike` in `do!` and `let!` similar to F#'s `task`, this includes non-generic `Task` and `ValueTask` with `do!`

### DIFF
--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="TaskSeq.AsyncExtensions.Tests.fs" />
     <Compile Include="TaskSeq.TaskExtensions.Tests.fs" />
     <Compile Include="TaskSeq.Do.Tests.fs" />
+    <Compile Include="TaskSeq.Let.Tests.fs" />
     <Compile Include="TaskSeq.Using.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="TaskSeq.Realworld.fs" />
     <Compile Include="TaskSeq.AsyncExtensions.Tests.fs" />
     <Compile Include="TaskSeq.TaskExtensions.Tests.fs" />
+    <Compile Include="TaskSeq.Do.Tests.fs" />
     <Compile Include="TaskSeq.Using.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Do.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Do.Tests.fs
@@ -1,0 +1,48 @@
+module TaskSeq.Tests.Do
+
+open System
+open System.Threading.Tasks
+open FsUnit
+open Xunit
+
+open FSharp.Control
+
+[<Fact>]
+let ``CE taskSeq: use 'do'`` () =
+    let mutable value = 0
+
+    taskSeq { do value <- value + 1 }
+
+    |> verifyEmpty
+
+[<Fact>]
+let ``CE taskSeq: use 'do!' with a task<unit>`` () =
+    let mutable value = 0
+
+    taskSeq { do! task { do value <- value + 1 } }
+
+    |> verifyEmpty
+
+//[<Fact>]
+//let ``CE taskSeq: use 'do!' with a valuetask<unit>`` () =
+//    let mutable value = 0
+
+//    taskSeq { do! ValueTask.ofIValueTaskSource (task { do value <- value + 1 }) }
+
+//    |> verifyEmpty
+
+//[<Fact>]
+//let ``CE taskSeq: use 'do!' with a non-generic valuetask`` () =
+//    let mutable value = 0
+
+//    taskSeq { do! ValueTask(task { do value <- value + 1 }) }
+
+//    |> verifyEmpty
+
+//[<Fact>]
+//let ``CE taskSeq: use 'do!' with a non-generic task`` () =
+//    let mutable value = 0
+
+//    taskSeq { do! (task { do value <- value + 1 }) |> Task.ignore }
+
+//    |> verifyEmpty

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Do.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Do.Tests.fs
@@ -11,38 +11,36 @@ open FSharp.Control
 let ``CE taskSeq: use 'do'`` () =
     let mutable value = 0
 
-    taskSeq { do value <- value + 1 }
-
-    |> verifyEmpty
+    taskSeq { do value <- value + 1 } |> verifyEmpty
 
 [<Fact>]
 let ``CE taskSeq: use 'do!' with a task<unit>`` () =
     let mutable value = 0
 
     taskSeq { do! task { do value <- value + 1 } }
-
     |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)
 
-//[<Fact>]
-//let ``CE taskSeq: use 'do!' with a valuetask<unit>`` () =
-//    let mutable value = 0
+[<Fact>]
+let ``CE taskSeq: use 'do!' with a valuetask<unit>`` () =
+    let mutable value = 0
 
-//    taskSeq { do! ValueTask.ofIValueTaskSource (task { do value <- value + 1 }) }
+    taskSeq { do! ValueTask.ofTask (task { do value <- value + 1 }) }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)
 
-//    |> verifyEmpty
+[<Fact>]
+let ``CE taskSeq: use 'do!' with a non-generic valuetask`` () =
+    let mutable value = 0
 
-//[<Fact>]
-//let ``CE taskSeq: use 'do!' with a non-generic valuetask`` () =
-//    let mutable value = 0
+    taskSeq { do! ValueTask(task { do value <- value + 1 }) }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)
 
-//    taskSeq { do! ValueTask(task { do value <- value + 1 }) }
+[<Fact>]
+let ``CE taskSeq: use 'do!' with a non-generic task`` () =
+    let mutable value = 0
 
-//    |> verifyEmpty
-
-//[<Fact>]
-//let ``CE taskSeq: use 'do!' with a non-generic task`` () =
-//    let mutable value = 0
-
-//    taskSeq { do! (task { do value <- value + 1 }) |> Task.ignore }
-
-//    |> verifyEmpty
+    taskSeq { do! (task { do value <- value + 1 }) |> Task.ignore }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Do.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Do.Tests.fs
@@ -44,3 +44,15 @@ let ``CE taskSeq: use 'do!' with a non-generic task`` () =
     taskSeq { do! (task { do value <- value + 1 }) |> Task.ignore }
     |> verifyEmpty
     |> Task.map (fun _ -> value |> should equal 1)
+
+[<Fact>]
+let ``CE taskSeq: use 'do!' with a task-delay`` () =
+    let mutable value = 0
+
+    taskSeq {
+        do value <- value + 1
+        do! Task.Delay 50
+        do value <- value + 1
+    }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 2)

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Let.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Let.Tests.fs
@@ -1,0 +1,82 @@
+module TaskSeq.Tests.Let
+
+open System
+open System.Threading.Tasks
+open FsUnit
+open Xunit
+
+open FSharp.Control
+
+[<Fact>]
+let ``CE taskSeq: use 'let'`` () =
+    let mutable value = 0
+
+    taskSeq {
+        let value1 = value + 1
+        let value2 = value1 + 1
+        yield value2
+    }
+    |> TaskSeq.exactlyOne
+    |> Task.map (should equal 2)
+
+[<Fact>]
+let ``CE taskSeq: use 'let!' with a task<unit>`` () =
+    let mutable value = 0
+
+    taskSeq {
+        let! unit' = task { do value <- value + 1 }
+        do unit'
+    }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)
+
+[<Fact>]
+let ``CE taskSeq: use 'let!' with a task<string>`` () =
+    taskSeq {
+        let! test = task { return "test" }
+        yield test
+    }
+    |> TaskSeq.exactlyOne
+    |> Task.map (should equal "test")
+
+[<Fact>]
+let ``CE taskSeq: use 'let!' with a valuetask<unit>`` () =
+    let mutable value = 0
+
+    taskSeq {
+        let! unit' = ValueTask.ofTask (task { do value <- value + 1 })
+        do unit'
+    }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)
+
+[<Fact>]
+let ``CE taskSeq: use 'let!' with a valuetask<string>`` () =
+    taskSeq {
+        let! test = ValueTask.ofTask (task { return "test" })
+        yield test
+    }
+    |> TaskSeq.exactlyOne
+    |> Task.map (should equal "test")
+
+[<Fact>]
+let ``CE taskSeq: use 'let!' with a non-generic valuetask`` () =
+    let mutable value = 0
+
+    taskSeq {
+        let! unit' = ValueTask(task { do value <- value + 1 })
+        do unit'
+    }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)
+
+[<Fact>]
+let ``CE taskSeq: use 'let!' with a non-generic task`` () =
+    let mutable value = 0
+
+    taskSeq {
+        let! unit' = (task { do value <- value + 1 }) |> Task.ignore
+        do unit'
+    }
+    |> verifyEmpty
+    |> Task.map (fun _ -> value |> should equal 1)

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
@@ -1,4 +1,4 @@
-module FSharp.Control.TaskSeq.Test
+module TaskSeq.Test.Using
 
 open System
 open System.Threading.Tasks
@@ -34,7 +34,7 @@ type private MultiDispose(disposed: int ref) =
 let private check = TaskSeq.length >> Task.map (should equal 1)
 
 [<Fact>]
-let ``CE task: Using when type implements IDisposable`` () =
+let ``CE taskSeq: Using when type implements IDisposable`` () =
     let disposed = ref false
 
     let ts = taskSeq {
@@ -46,7 +46,7 @@ let ``CE task: Using when type implements IDisposable`` () =
     |> Task.map (fun _ -> disposed.Value |> should be True)
 
 [<Fact>]
-let ``CE task: Using when type implements IAsyncDisposable`` () =
+let ``CE taskSeq: Using when type implements IAsyncDisposable`` () =
     let disposed = ref false
 
     let ts = taskSeq {
@@ -58,7 +58,7 @@ let ``CE task: Using when type implements IAsyncDisposable`` () =
     |> Task.map (fun _ -> disposed.Value |> should be True)
 
 [<Fact>]
-let ``CE task: Using when type implements IDisposable and IAsyncDisposable`` () =
+let ``CE taskSeq: Using when type implements IDisposable and IAsyncDisposable`` () =
     let disposed = ref 0
 
     let ts = taskSeq {
@@ -70,7 +70,7 @@ let ``CE task: Using when type implements IDisposable and IAsyncDisposable`` () 
     |> Task.map (fun _ -> disposed.Value |> should equal -1) // should prefer IAsyncDisposable, which returns -1
 
 [<Fact>]
-let ``CE task: Using! when type implements IDisposable`` () =
+let ``CE taskSeq: Using! when type implements IDisposable`` () =
     let disposed = ref false
 
     let ts = taskSeq {
@@ -82,7 +82,7 @@ let ``CE task: Using! when type implements IDisposable`` () =
     |> Task.map (fun _ -> disposed.Value |> should be True)
 
 [<Fact>]
-let ``CE task: Using! when type implements IAsyncDisposable`` () =
+let ``CE taskSeq: Using! when type implements IAsyncDisposable`` () =
     let disposed = ref false
 
     let ts = taskSeq {
@@ -94,7 +94,7 @@ let ``CE task: Using! when type implements IAsyncDisposable`` () =
     |> Task.map (fun _ -> disposed.Value |> should be True)
 
 [<Fact>]
-let ``CE task: Using! when type implements IDisposable and IAsyncDisposable`` () =
+let ``CE taskSeq: Using! when type implements IDisposable and IAsyncDisposable`` () =
     let disposed = ref 0
 
     let ts = taskSeq {

--- a/src/FSharp.Control.TaskSeq.Test/TestUtils.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TestUtils.fs
@@ -136,11 +136,13 @@ type DummyTaskFactory(µsecMin: int64<µs>, µsecMax: int64<µs>) =
 
 [<AutoOpen>]
 module TestUtils =
+    /// Verifies that a task sequence is empty by converting to an array and checking emptiness.
     let verifyEmpty ts =
         ts
         |> TaskSeq.toArrayAsync
         |> Task.map (Array.isEmpty >> should be True)
 
+    /// Verifies that a task sequence contains integers 1-10, by converting to an array and comparing.
     let verify1To10 ts =
         ts
         |> TaskSeq.toArrayAsync

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -635,7 +635,7 @@ module HighPriority =
         //
         member inline _.Bind(task: Task<'TResult1>, continuation: ('TResult1 -> TaskSeqCode<'T>)) : TaskSeqCode<'T> =
             TaskSeqCode<'T>(fun sm ->
-                let mutable awaiter: TaskAwaiter<'TResult1> = task.GetAwaiter()
+                let mutable awaiter = task.GetAwaiter()
                 let mutable __stack_fin = true
 
                 Debug.logInfo "at Bind"

--- a/src/FSharp.Control.TaskSeq/Utils.fs
+++ b/src/FSharp.Control.TaskSeq/Utils.fs
@@ -28,6 +28,16 @@ module ValueTask =
     /// Creates a ValueTask with an IValueTaskSource representing the operation
     let inline ofIValueTaskSource taskSource version = ValueTask<bool>(taskSource, version)
 
+    /// Creates a ValueTask form a Task<'T>
+    let inline ofTask (task: Task<'T>) = ValueTask<'T>(task)
+
+    /// Ignore a ValueTask<'T>, returns a non-generic ValueTask.
+    let inline ignore (vtask: ValueTask<'T>) =
+        if vtask.IsCompleted then
+            ValueTask()
+        else
+            ValueTask(vtask.AsTask())
+
 module Task =
     /// Convert an Async<'T> into a Task<'T>
     let inline ofAsync (async: Async<'T>) = task { return! async }
@@ -41,14 +51,8 @@ module Task =
     /// Convert a Task<'T> into an Async<'T>
     let inline toAsync (task: Task<'T>) = Async.AwaitTask task
 
-    /// Convert a Task<unit> into a Task
-    let inline toTask (task: Task<unit>) = task :> Task
-
     /// Convert a Task<'T> into a ValueTask<'T>
     let inline toValueTask (task: Task<'T>) = ValueTask<'T> task
-
-    /// Convert a Task<unit> into a non-generic ValueTask
-    let inline toIgnoreValueTask (task: Task<unit>) = ValueTask(task :> Task)
 
     /// <summary>
     /// Convert a ValueTask&lt;'T> to a Task&lt;'T>. To use a non-generic ValueTask,
@@ -56,7 +60,7 @@ module Task =
     /// </summary>
     let inline ofValueTask (valueTask: ValueTask<'T>) = task { return! valueTask }
 
-    /// Convert a Task<'T> into a Task, ignoring the result
+    /// Convert a Task<'T> into a non-generic Task, ignoring the result
     let inline ignore (task: Task<'T>) =
         TaskBuilder.task {
             let! _ = task


### PR DESCRIPTION
Fixes #43.
Fixes #110.

This basically allows:

```f#
let t = task { return 10 } :> Task  // ignore by casting to Task
let ts = taskSeq { do! t } // currently not supported, must be Task<unit>
let ts = taskSeq { do! Task.Delay 10 } // currently not supported
```

On top of that, this PR will add support for all of `^TaskLike` that F#'s `task` also supports. This change is necessary, as the above distinction isn't possible by adding an overload for the non-generic `Task` and `ValueTask`, for the simple reason that `Task<'T> :> Task`.

The solution chosen in F# was to have a `Bind` implementation that takes an SRTP parameter of `^TaskLike`, which has a `GetAwaiter() -> 'T when 'T :> ICriticalNotifyCompletion`, as follows:

```f#
member inline _.Bind< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter, 'TOverall
    when ^TaskLike: (member GetAwaiter: unit -> ^Awaiter)
    and ^Awaiter :> ICriticalNotifyCompletion
    and ^Awaiter: (member get_IsCompleted: unit -> bool)
    and ^Awaiter: (member GetResult: unit -> 'TResult1)

    ... resumable code implementation ...
```

Because `Task<'T>` does have a `GetAwaiter` _on the type_, but also inherits `Task` which in turn implements the non-generic `TaskAwaiter`, a conflict arises causing an "ambiguous overload" error with just the code above. To solve this, a high-priority overload `Bind` for `Task<'T>` is added, which specifically pick the `Task<'T>.GetAwaiter: unit -> TaskAwaiter<'T>`, as opposed to `(Task<'T> :> Task).GetAwaiter: unit -> unit`.

Note that the non-generic `Task` only has the non-generic `GetResult: unit -> unit`, which fits the above signature where `'TResult1` becomes `unit`, and no ambiguity arises.

In other words, `TaskLike` are: `ValueTask`, `ValueTask<'T>`, `Task`. Not `TaskLike` per the above definition is `Task<'T>`, which has its own overload.