### PR TITLE
Add `let!` and `do!` support for F# `async` / `Async<'T>`

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,6 +1,7 @@
 
 Release notes:
 0.4.x (unreleased)
+    - adds `let!` and `do!` support for F#'s Async<'T>
     - adds TaskSeq.takeWhile, takeWhileAsync, takeWhileInclusive, takeWhileInclusiveAsync, #126 (by @bartelink)
     - adds AsyncSeq vs TaskSeq comparison chart, #131
 

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
@@ -191,3 +191,5 @@ module HighPriority =
     type TaskSeqBuilder with
 
         member inline Bind: task: Task<'TResult1> * continuation: ('TResult1 -> ResumableTSC<'T>) -> ResumableTSC<'T>
+        member inline Bind:
+            asyncSource: Async<'TResult1> * continuation: ('TResult1 -> ResumableTSC<'T>) -> ResumableTSC<'T>


### PR DESCRIPTION
Fixes: #79 

This introduces `async` support similar to how `task` supports `async` through let-bang and do-bang. 

----

### Original PR contained the following, which has been moved to #132 and #133.

I'm not certain whether or not to allow this (creative?) approach of setting a `CancellationToken`.

Basically, if we'd merge this, setting a `CancellationToken` can be done as follows:

```f#
let f() =
    let tokenSource = CancellationTokenSource(500)
    taskSeq {
        do! tokenSource.Token // this sets the token for this taskSeq
        do! Task.Delay 300
        do! Task.Delay 300
        do! Task.Delay 300
    }
```

@dsyme, what do you think? In a way I think it is smoother than adding overloads to all the `TaskSeq.XXX` functions to take a cancellation token. Alternatively, of course, I could just have a `TaskSeq.setCancellationToken` method. However, the above way is very flexible.

The relatively simple way this is done is as follows:

```f#
member inline _.Bind(myToken: CancellationToken, continuation: (unit -> TaskSeqCode<'T>)) : TaskSeqCode<'T> =
    TaskSeqCode<'T>(fun sm ->
        sm.Data.cancellationToken <- myToken
        (continuation ()).Invoke(&sm))
```

Which **may** also be a way to allow cancellation tokens to be passed through in tasks (but, it adds overhead).