### PR TITLE
Release NuGet version 0.3.0

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.2</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,8 +1,8 @@
 
 Release notes:
 
-0.3.0 (unreleased)
-    - internal renames, improved doc comments, signature files for complex types, hide internal-only types, #111.
+0.3.0
+    - internal renames, improved doc comments, signature files for complex types, hide internal-only types, fixes #112.
     - adds support for static TaskLike, allowing the same let! and do! overloads that F# task supports, fixes #110.
     - implements 'do!' for non-generic Task like with Task.Delay, fixes #43.
     - adds support for 'for .. in ..' with task sequences in F# tasks and async, #75, #93 and #99 (with help from @theangrybyrd).


### PR DESCRIPTION
After being merged, this PR releases version 0.3.0 to NuGet.