### PR TITLE
Add nuget smoketests

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <!-- updating this version will trigger a publish after merge to 'main' -->
     <Version>0.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
@@ -8,14 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="C:\Users\Abel\.nuget\packages\fsharp.control.taskseq\0.3.0\contentFiles\any\netstandard2.1\release-notes.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="SmokeTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.2.2" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.3.0" />
+    <PackageReference Include="FsUnit.xUnit" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SmokeTests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/FSharp.Control.TaskSeq.SmokeTests/Program.fs
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/src/FSharp.Control.TaskSeq.SmokeTests/SmokeTests.fs
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/SmokeTests.fs
@@ -1,0 +1,44 @@
+module Tests
+
+open System
+open System.Threading.Tasks
+open Xunit
+open FSharp.Control
+
+[<Fact>]
+let ``Use and execute a taskSeq from nuget`` () =
+    taskSeq { yield 10 }
+    |> TaskSeq.toArray
+    |> fun x -> Assert.Equal<int array>(x, [| 10 |])
+
+[<Fact>]
+let ``Use and execute a taskSeq from nuget with multiple keywords`` () =
+    taskSeq {
+        do! task { do! Task.Delay 10 }
+        let! x = task { return 1 }
+        yield x
+        let! vt = ValueTask<int>(task { return 2 })
+        yield vt
+        yield 10
+    }
+    |> TaskSeq.toArray
+    |> fun x -> Assert.Equal<int array>(x, [| 1; 2; 10 |])
+
+// from version 0.3.0:
+
+//[<Fact>]
+//let ``Use and execute a taskSeq from nuget with multiple keywords v0.3.0`` () =
+//    taskSeq {
+//        do! task { do! Task.Delay 10 }
+//        do! Task.Delay 10 // only in 0.3
+//        let! x = task { return 1 } :> Task // only in 0.3
+//        yield 1
+//        let! vt = ValueTask<int> ( task { return 2 } )
+//        yield vt
+//        let! vt = ValueTask ( task { return 2 } ) // only in 0.3
+//        do! ValueTask ( task { return 2 } ) // only in 0.3
+//        yield 3
+//        yield 10
+//    }
+//    |> TaskSeq.toArray
+//    |> fun x -> Assert.Equal<int array>(x, [| 1; 2; 3; 10 |])

--- a/src/FSharp.Control.TaskSeq.SmokeTests/SmokeTests.fs
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/SmokeTests.fs
@@ -4,15 +4,35 @@ open System
 open System.Threading.Tasks
 open Xunit
 open FSharp.Control
+open FsUnit.Xunit
+
+//
+// this file can be used to hand-test NuGet deploys
+// esp. when there are changes in the surface area
+//
+// This project gets compiled in CI, but is not part
+// of the structured test reports currently.
+// However, a compile error will fail the CI pipeline.
+//
+
+
+type private MultiDispose(disposed: int ref) =
+    member _.Get1() = 1
+
+    interface IDisposable with
+        member _.Dispose() = disposed.Value <- 1
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() = ValueTask(task { do disposed.Value <- -1 })
 
 [<Fact>]
-let ``Use and execute a taskSeq from nuget`` () =
+let ``Use and execute a minimal taskSeq from nuget`` () =
     taskSeq { yield 10 }
     |> TaskSeq.toArray
     |> fun x -> Assert.Equal<int array>(x, [| 10 |])
 
 [<Fact>]
-let ``Use and execute a taskSeq from nuget with multiple keywords`` () =
+let ``Use taskSeq from nuget with multiple keywords v0.2.2`` () =
     taskSeq {
         do! task { do! Task.Delay 10 }
         let! x = task { return 1 }
@@ -26,19 +46,52 @@ let ``Use and execute a taskSeq from nuget with multiple keywords`` () =
 
 // from version 0.3.0:
 
-//[<Fact>]
-//let ``Use and execute a taskSeq from nuget with multiple keywords v0.3.0`` () =
-//    taskSeq {
-//        do! task { do! Task.Delay 10 }
-//        do! Task.Delay 10 // only in 0.3
-//        let! x = task { return 1 } :> Task // only in 0.3
-//        yield 1
-//        let! vt = ValueTask<int> ( task { return 2 } )
-//        yield vt
-//        let! vt = ValueTask ( task { return 2 } ) // only in 0.3
-//        do! ValueTask ( task { return 2 } ) // only in 0.3
-//        yield 3
-//        yield 10
-//    }
-//    |> TaskSeq.toArray
-//    |> fun x -> Assert.Equal<int array>(x, [| 1; 2; 3; 10 |])
+[<Fact>]
+let ``Use taskSeq from nuget with multiple keywords v0.3.0`` () =
+    taskSeq {
+        do! task { do! Task.Delay 10 }
+        do! Task.Delay 10 // only in 0.3
+        let! x = task { return 1 } :> Task // only in 0.3
+        yield 1
+        let! vt = ValueTask<int>(task { return 2 })
+        yield vt
+        let! vt = ValueTask(task { return 2 }) // only in 0.3
+        do! ValueTask(task { return 2 }) // only in 0.3
+        yield 3
+        yield 10
+    }
+    |> TaskSeq.toArray
+    |> fun x -> Assert.Equal<int array>(x, [| 1; 2; 3; 10 |])
+
+[<Fact>]
+let ``Use taskSeq when type implements IDisposable and IAsyncDisposable`` () =
+    let disposed = ref 0
+
+    let ts = taskSeq {
+        use! x = task { return new MultiDispose(disposed) } // Used to fail to compile (see #97, fixed in v0.3.0)
+        yield x.Get1()
+    }
+
+    ts
+    |> TaskSeq.length
+    |> Task.map (should equal 1)
+    |> Task.map (fun _ -> disposed.Value |> should equal -1) // must favor IAsyncDisposable, not IDisposable
+
+[<Fact>]
+let ``Use taskSeq as part of an F# task CE`` () = task {
+    let ts = taskSeq { yield! [ 0..99 ] }
+    let ra = ResizeArray()
+
+    // loop through a taskSeq, support added in v0.3.0
+    for v in ts do
+        ra.Add v
+
+    ra.ToArray() |> should equal [| 0..99 |]
+}
+
+[<Fact>]
+let ``New surface area functions availability tests v0.3.0`` () = task {
+    let ts = TaskSeq.singleton 10 // added in v0.3.0
+    let! ls = TaskSeq.toListAsync ts
+    List.exactlyOne ls |> should equal 10
+}

--- a/src/FSharp.Control.TaskSeq.sln
+++ b/src/FSharp.Control.TaskSeq.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{B198D5
 		..\assets\taskseq-icon.png = ..\assets\taskseq-icon.png
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Control.TaskSeq.SmokeTests", "FSharp.Control.TaskSeq.SmokeTests\FSharp.Control.TaskSeq.SmokeTests.fsproj", "{784DAB92-C61A-4A00-890B-E6E3B1805473}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +50,10 @@ Global
 		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06CA2C7E-04DA-4A85-BB8E-4D94BD67AEB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{784DAB92-C61A-4A00-890B-E6E3B1805473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{784DAB92-C61A-4A00-890B-E6E3B1805473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{784DAB92-C61A-4A00-890B-E6E3B1805473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{784DAB92-C61A-4A00-890B-E6E3B1805473}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Just some tests to ensure that public functions are actually available in the latest version, in particular w.r.t. additions to the computation expression overloads, which has now been severely overhauled.