### PR TITLE
Downgrade FsToolkit.ErrorHandling.TaskResult, as it still gives warnings because it references F# 7.0

### DIFF
--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -58,7 +58,7 @@
     <!-- align test project with minimal required version for TaskSeq -->
     <!-- we use 6.0.3 here and not 6.0.2 because TaskResult lib requires it-->
     <PackageReference Update="FSharp.Core" Version="6.0.3" />
-    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="3.3.1" />
+    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="3.2.0" />
     <PackageReference Include="FsUnit.xUnit" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
As in the title. A recent dependabot update in #117 suggested this change, but it wasn't immediately obvious that 3.3.x of FsToolkit references the F# Core 7.0 assembly.