### PR TITLE
Use FSharp.Core 6.0.1 instead of 6.0.2, lowest denominator approach for versions

### DIFF
--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -59,6 +59,6 @@ Generates optimized IL code through the new resumable state machines, and comes 
 
   <ItemGroup>
     <!-- maximal compatibility with minimal required FSharp.Core version for TaskSeq -->
-    <PackageReference Update="FSharp.Core" Version="6.0.2" />
+    <PackageReference Update="FSharp.Core" Version="6.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: #121.

~Just running full CI to see what happens.~ All tests pass just fine. Let's downgrade the lowest supported FSharp.Core.dll version.

Note that we _cannot go all the way to 6.0.0_, unless we write the `taskSeq` overload code such that we don't use `NoEagerConstraintApplication`. This means either marker interfaces, or explicits (i.e., require users to do `Task.ofAsync` and the like). I'm fine with using this approach though, as it behaves closer to how `task` behaves.