### PR TITLE
Add null-checks for each function that takes an `IAsyncEnumerable` or otherwise nullable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,8 @@ The following are the current surface area of the `TaskSeq` utility functions, o
 
 ```f#
 module TaskSeq =
-    val append: source1: #taskSeq<'T> -> source2: #taskSeq<'T> -> taskSeq<'T>
-    val appendSeq: source1: #taskSeq<'T> -> source2: #seq<'T> -> taskSeq<'T>
+    val append: source1: taskSeq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
+    val appendSeq: source1: taskSeq<'T> -> source2: seq<'T> -> taskSeq<'T>
     val box: source: taskSeq<'T> -> taskSeq<obj>
     val cast: source: taskSeq<obj> -> taskSeq<'T>
     val choose: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> taskSeq<'U>
@@ -522,7 +522,7 @@ module TaskSeq =
     val ofTaskSeq: source: seq<#Task<'T>> -> taskSeq<'T>
     val pick: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> Task<'U>
     val pickAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> Task<'U>
-    val prependSeq: source1: #seq<'T> -> source2: #taskSeq<'T> -> taskSeq<'T>
+    val prependSeq: source1: seq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
     val singleton: source: 'T -> taskSeq<'T>
     val tail: source: taskSeq<'T> -> Task<taskSeq<'T>>
     val takeWhile: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<taskSeq<'T>>

--- a/src/FSharp.Control.TaskSeq.Test/Nunit.Extensions.fs
+++ b/src/FSharp.Control.TaskSeq.Test/Nunit.Extensions.fs
@@ -169,3 +169,6 @@ module ExtraCustomMatchers =
             $"Throws %s{ex.Name} (Below, XUnit does not show actual value properly)",
             (fun fn -> (testForThrowing (fn :?> (unit -> Task))).Result)
         )
+
+    let inline assertThrows ty (f: unit -> 'U) = f >> ignore |> should throw ty
+    let inline assertNullArg f = assertThrows typeof<ArgumentNullException> f

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Append.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Append.Tests.fs
@@ -23,6 +23,14 @@ let validateSequence ts =
     |> Task.map (should equal "1234567891012345678910")
 
 module EmptySeq =
+    let ``Null source is invalid`` () =
+        let test1 () = TaskSeq.empty |> TaskSeq.append null |> TaskSeq.toList
+        let test2 () = null |> TaskSeq.append TaskSeq.empty |> TaskSeq.toList
+        let test3 () = null |> TaskSeq.append null |> TaskSeq.toList
+        test1 |> should throw typeof<ArgumentNullException>
+        test2 |> should throw typeof<ArgumentNullException>
+        test3 |> should throw typeof<ArgumentNullException>
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-append both args empty`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Append.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Append.Tests.fs
@@ -22,14 +22,17 @@ let validateSequence ts =
     |> Task.map (String.concat "")
     |> Task.map (should equal "1234567891012345678910")
 
+
 module EmptySeq =
+    [<Fact>]
     let ``Null source is invalid`` () =
-        let test1 () = TaskSeq.empty |> TaskSeq.append null |> TaskSeq.toList
-        let test2 () = null |> TaskSeq.append TaskSeq.empty |> TaskSeq.toList
-        let test3 () = null |> TaskSeq.append null |> TaskSeq.toList
-        test1 |> should throw typeof<ArgumentNullException>
-        test2 |> should throw typeof<ArgumentNullException>
-        test3 |> should throw typeof<ArgumentNullException>
+        assertNullArg
+        <| fun () -> TaskSeq.empty |> TaskSeq.append null
+
+        assertNullArg
+        <| fun () -> null |> TaskSeq.append TaskSeq.empty
+
+        assertNullArg <| fun () -> null |> TaskSeq.append null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-append both args empty`` variant =

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Cast.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Cast.Tests.fs
@@ -23,6 +23,9 @@ let validateSequence ts =
     |> Task.map (should equal "12345678910")
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () = assertNullArg <| fun () -> TaskSeq.box null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-box empty`` variant = Gen.getEmptyVariant variant |> TaskSeq.box |> verifyEmpty
 

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Cast.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Cast.Tests.fs
@@ -24,7 +24,10 @@ let validateSequence ts =
 
 module EmptySeq =
     [<Fact>]
-    let ``Null source is invalid`` () = assertNullArg <| fun () -> TaskSeq.box null
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.box null
+        assertNullArg <| fun () -> TaskSeq.unbox null
+        assertNullArg <| fun () -> TaskSeq.cast null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-box empty`` variant = Gen.getEmptyVariant variant |> TaskSeq.box |> verifyEmpty

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Choose.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Choose.Tests.fs
@@ -10,13 +10,19 @@ open FsToolkit.ErrorHandling
 open FSharp.Control
 
 //
-// TaskSeq.map
-// TaskSeq.mapi
-// TaskSeq.mapAsync
-// TaskSeq.mapiAsync
+// TaskSeq.choose
+// TaskSeq.chooseAsync
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.choose (fun _ -> None) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.chooseAsync (fun _ -> Task.fromResult None) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-choose`` variant = task {
         let! empty =

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Collect.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Collect.Tests.fs
@@ -12,6 +12,13 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.collect (fun _ -> TaskSeq.empty) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.collectAsync (fun _ -> Task.fromResult TaskSeq.empty) null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-collect collecting emptiness`` variant =

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Concat.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Concat.Tests.fs
@@ -21,6 +21,9 @@ let validateSequence ts =
     |> Task.map (should equal "123456789101234567891012345678910")
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () = assertNullArg <| fun () -> TaskSeq.concat null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-concat with empty sequences`` variant =
         taskSeq {

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Contains.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Contains.Tests.fs
@@ -11,6 +11,9 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () = assertNullArg <| fun () -> TaskSeq.contains 42 null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-contains returns false`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Empty.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Empty.Tests.fs
@@ -62,3 +62,29 @@ let ``TaskSeq-empty multiple times in a taskSeq context`` () = task {
 
     Array.isEmpty sq |> should be True
 }
+
+[<Fact>]
+let ``TaskSeq-empty multiple times with side effects`` () = task {
+    let mutable x = 0
+
+    let sq = taskSeq {
+        yield! TaskSeq.empty<string>
+        yield! TaskSeq.empty<string>
+        x <- x + 1
+        yield! TaskSeq.empty<string>
+        x <- x + 1
+        yield! TaskSeq.empty<string>
+        x <- x + 1
+        yield! TaskSeq.empty<string>
+        x <- x + 1
+        x <- x + 1
+    }
+
+    // executing side effects once
+    (TaskSeq.toArray >> Array.isEmpty) sq |> should be True
+    x |> should equal 5
+
+    // twice
+    (TaskSeq.toArray >> Array.isEmpty) sq |> should be True
+    x |> should equal 10
+}

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.ExactlyOne.Tests.fs
@@ -13,6 +13,11 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.exactlyOne null
+        assertNullArg <| fun () -> TaskSeq.tryExactlyOne null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-exactlyOne throws`` variant = task {
         fun () ->

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Except.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Except.Tests.fs
@@ -14,6 +14,20 @@ open FSharp.Control
 
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.except null TaskSeq.empty
+        assertNullArg <| fun () -> TaskSeq.except TaskSeq.empty null
+        assertNullArg <| fun () -> TaskSeq.except null null
+
+        assertNullArg
+        <| fun () -> TaskSeq.exceptOfSeq null TaskSeq.empty
+
+        assertNullArg
+        <| fun () -> TaskSeq.exceptOfSeq Seq.empty null
+
+        assertNullArg <| fun () -> TaskSeq.exceptOfSeq null null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-except`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Exists.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Exists.Tests.fs
@@ -12,6 +12,14 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.exists (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.existsAsync (fun _ -> Task.fromResult false) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-exists returns false`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Filter.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Filter.Tests.fs
@@ -14,6 +14,15 @@ open FSharp.Control
 
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.filter (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.filterAsync (fun _ -> Task.fromResult false) null
+
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-filter has no effect`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Find.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Find.Tests.fs
@@ -15,6 +15,20 @@ open System.Collections.Generic
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.find (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.findAsync (fun _ -> Task.fromResult false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.tryFind (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.tryFindAsync (fun _ -> Task.fromResult false) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-find raises KeyNotFoundException`` variant =
         fun () ->

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.FindIndex.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.FindIndex.Tests.fs
@@ -15,6 +15,20 @@ open System.Collections.Generic
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.findIndex (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.findIndexAsync (fun _ -> Task.fromResult false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.tryFindIndex (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.tryFindIndexAsync (fun _ -> Task.fromResult false) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-findIndex raises KeyNotFoundException`` variant =
         fun () ->

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Fold.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Fold.Tests.fs
@@ -13,6 +13,14 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.fold (fun _ _ -> 42) 0 null
+
+        assertNullArg
+        <| fun () -> TaskSeq.foldAsync (fun _ _ -> Task.fromResult 42) 0 null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-fold takes state when empty`` variant = task {
         let! empty =

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Head.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Head.Tests.fs
@@ -13,6 +13,10 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.head null
+        assertNullArg <| fun () -> TaskSeq.tryHead null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-head throws`` variant = task {

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Indexed.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Indexed.Tests.fs
@@ -11,6 +11,9 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () = assertNullArg <| fun () -> TaskSeq.indexed null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-indexed on empty`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.IsEmpty.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.IsEmpty.fs
@@ -60,6 +60,21 @@ module SideEffects =
         |> Task.map (should be True)
         |> Task.map (fun () -> i |> should equal 2)
 
+    [<Fact>]
+    let ``TaskSeq-isEmpty executes side effects each time`` () =
+        let mutable i = 0
+
+        taskSeq {
+            i <- i + 1
+            i <- i + 1
+        }
+        |>> TaskSeq.isEmpty
+        |>> TaskSeq.isEmpty
+        |>> TaskSeq.isEmpty
+        |> TaskSeq.isEmpty // 4th time: 8
+        |> Task.map (should be True)
+        |> Task.map (fun () -> i |> should equal 8)
+
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
     let ``TaskSeq-isEmpty returns false for non-empty`` variant =
         Gen.getSeqWithSideEffect variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.IsEmpty.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.IsEmpty.fs
@@ -7,7 +7,13 @@ open FsToolkit.ErrorHandling
 
 open FSharp.Control
 
+//
+// TaskSeq.isEmpty
+//
+
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () = assertNullArg <| fun () -> TaskSeq.head null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-isEmpty returns true for empty`` variant =

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Item.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Item.Tests.fs
@@ -13,6 +13,11 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.item 42 null
+        assertNullArg <| fun () -> TaskSeq.tryItem 42 null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-item throws on empty sequences`` variant = task {
         fun () -> Gen.getEmptyVariant variant |> TaskSeq.item 0 |> Task.ignore

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Iter.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Iter.Tests.fs
@@ -13,6 +13,19 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.iter (fun _ -> ()) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.iteri (fun _ _ -> ()) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.iterAsync (fun _ -> Task.fromResult ()) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.iteriAsync (fun _ _ -> Task.fromResult ()) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-iteri does nothing on empty sequences`` variant = task {
         let tq = Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Last.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Last.Tests.fs
@@ -13,6 +13,10 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.last null
+        assertNullArg <| fun () -> TaskSeq.tryLast null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-last throws`` variant = task {

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Length.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Length.Tests.fs
@@ -14,6 +14,16 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.length null
+
+        assertNullArg
+        <| fun () -> TaskSeq.lengthBy (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.lengthByAsync (fun _ -> Task.fromResult false) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-length returns zero on empty sequences`` variant = task {
         let! len = Gen.getEmptyVariant variant |> TaskSeq.length

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Map.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Map.Tests.fs
@@ -35,6 +35,17 @@ let validateSequenceWithOffset offset ts =
     |> Task.map (should equal expected)
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.map (fun _ -> ()) null
+        assertNullArg <| fun () -> TaskSeq.mapi (fun _ _ -> ()) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.mapAsync (fun _ -> Task.fromResult ()) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.mapiAsync (fun _ _ -> Task.fromResult ()) null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-map empty`` variant =
         Gen.getEmptyVariant variant

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.OfXXX.Tests.fs
@@ -12,6 +12,17 @@ let validateSequence sq =
 
 module EmptySeq =
     [<Fact>]
+    let ``Null source is invalid`` () =
+        // note: ofList and its variants do not have null as proper value
+        assertNullArg <| fun () -> TaskSeq.ofAsyncArray null
+        assertNullArg <| fun () -> TaskSeq.ofAsyncSeq null
+        assertNullArg <| fun () -> TaskSeq.ofTaskArray null
+        assertNullArg <| fun () -> TaskSeq.ofTaskSeq null
+        assertNullArg <| fun () -> TaskSeq.ofResizeArray null
+        assertNullArg <| fun () -> TaskSeq.ofArray null
+        assertNullArg <| fun () -> TaskSeq.ofSeq null
+
+    [<Fact>]
     let ``TaskSeq-ofAsyncArray with empty set`` () =
         Array.init 0 (fun x -> async { return x })
         |> TaskSeq.ofAsyncArray

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Tail.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Tail.Tests.fs
@@ -13,6 +13,10 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.tail null
+        assertNullArg <| fun () -> TaskSeq.tryTail null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-tail throws`` variant = task {

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -1,10 +1,23 @@
 module TaskSeq.Tests.``taskSeq Computation Expression``
 
+open System
+
 open Xunit
 open FsUnit.Xunit
 open FsToolkit.ErrorHandling
 
 open FSharp.Control
+
+[<Fact>]
+let ``CE taskSeq using yield! with null`` () = task {
+    let ts = taskSeq {
+        yield! Gen.sideEffectTaskSeq 10
+        yield! (null: taskSeq<int>)
+    }
+
+    fun () -> TaskSeq.toList ts
+    |> assertThrows typeof<NullReferenceException>
+}
 
 [<Fact>]
 let ``CE taskSeq with several yield!`` () = task {

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Using.Tests.fs
@@ -1,4 +1,4 @@
-module TaskSeq.Test.Using
+module TaskSeq.Tests.Using
 
 open System
 open System.Threading.Tasks

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Zip.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Zip.Tests.fs
@@ -12,6 +12,12 @@ open FSharp.Control
 //
 
 module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg <| fun () -> TaskSeq.zip null TaskSeq.empty
+        assertNullArg <| fun () -> TaskSeq.zip TaskSeq.empty null
+        assertNullArg <| fun () -> TaskSeq.zip null null
+
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
     let ``TaskSeq-zip can zip empty sequences v1`` variant =
         TaskSeq.zip (Gen.getEmptyVariant variant) (Gen.getEmptyVariant variant)

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -197,11 +197,8 @@ module TaskSeq =
     //
 
     let cast source : taskSeq<'T> = Internal.map (SimpleAction(fun (x: obj) -> x :?> 'T)) source
-    let box source = Internal.map (SimpleAction(fun x -> box x)) source
-
-    let unbox<'U when 'U: struct> (source: taskSeq<obj>) : taskSeq<'U> =
-        Internal.map (SimpleAction(fun x -> unbox x)) source
-
+    let box source = Internal.map (SimpleAction box) source
+    let unbox<'U when 'U: struct> (source: taskSeq<obj>) : taskSeq<'U> = Internal.map (SimpleAction unbox) source
     let iter action source = Internal.iter (SimpleAction action) source
     let iteri action source = Internal.iter (CountableAction action) source
     let iterAsync action source = Internal.iter (AsyncSimpleAction action) source
@@ -210,12 +207,9 @@ module TaskSeq =
     let mapi (mapper: int -> 'T -> 'U) source = Internal.map (CountableAction mapper) source
     let mapAsync mapper source = Internal.map (AsyncSimpleAction mapper) source
     let mapiAsync mapper source = Internal.map (AsyncCountableAction mapper) source
-    let collect (binder: 'T -> #IAsyncEnumerable<'U>) source = Internal.collect binder source
+    let collect (binder: 'T -> #taskSeq<'U>) source = Internal.collect binder source
     let collectSeq (binder: 'T -> #seq<'U>) source = Internal.collectSeq binder source
-
-    let collectAsync (binder: 'T -> #Task<#IAsyncEnumerable<'U>>) source : taskSeq<'U> =
-        Internal.collectAsync binder source
-
+    let collectAsync (binder: 'T -> #Task<#taskSeq<'U>>) source : taskSeq<'U> = Internal.collectAsync binder source
     let collectSeqAsync (binder: 'T -> #Task<#seq<'U>>) source : taskSeq<'U> = Internal.collectSeqAsync binder source
 
     //

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -236,47 +236,39 @@ module TaskSeq =
 
     let tryHead source = Internal.tryHead source
 
-    let head source = task {
-        match! Internal.tryHead source with
-        | Some head -> return head
-        | None -> return Internal.raiseEmptySeq ()
-    }
+    let head source =
+        Internal.tryHead source
+        |> Task.map (Option.defaultWith Internal.raiseEmptySeq)
 
     let tryLast source = Internal.tryLast source
 
-    let last source = task {
-        match! Internal.tryLast source with
-        | Some last -> return last
-        | None -> return Internal.raiseEmptySeq ()
-    }
+    let last source =
+        Internal.tryLast source
+        |> Task.map (Option.defaultWith Internal.raiseEmptySeq)
 
     let tryTail source = Internal.tryTail source
 
-    let tail source = task {
-        match! Internal.tryTail source with
-        | Some result -> return result
-        | None -> return Internal.raiseEmptySeq ()
-    }
+    let tail source =
+        Internal.tryTail source
+        |> Task.map (Option.defaultWith Internal.raiseEmptySeq)
 
     let tryItem index source = Internal.tryItem index source
 
-    let item index source = task {
-        match! Internal.tryItem index source with
-        | Some item -> return item
-        | None ->
-            if index < 0 then
-                return invalidArg (nameof index) "The input must be non-negative."
-            else
-                return Internal.raiseInsufficient ()
-    }
+    let item index source =
+        if index < 0 then
+            invalidArg (nameof index) "The input must be non-negative."
+
+        Internal.tryItem index source
+        |> Task.map (Option.defaultWith Internal.raiseInsufficient)
 
     let tryExactlyOne source = Internal.tryExactlyOne source
 
-    let exactlyOne source = task {
-        match! Internal.tryExactlyOne source with
-        | Some item -> return item
-        | None -> return invalidArg (nameof source) "The input sequence contains more than one element."
-    }
+    let exactlyOne source =
+        Internal.tryExactlyOne source
+        |> Task.map (
+            Option.defaultWith (fun () ->
+                invalidArg (nameof source) "The input sequence contains more than one element.")
+        )
 
     let indexed (source: taskSeq<'T>) =
         Internal.checkNonNull (nameof source) source
@@ -318,47 +310,34 @@ module TaskSeq =
         Internal.tryFind (Predicate((=) value)) source
         |> Task.map (Option.isSome)
 
-    let pick chooser source = task {
-        match! Internal.tryPick (TryPick chooser) source with
-        | Some item -> return item
-        | None -> return Internal.raiseNotFound ()
-    }
+    let pick chooser source =
+        Internal.tryPick (TryPick chooser) source
+        |> Task.map (Option.defaultWith Internal.raiseNotFound)
 
-    let pickAsync chooser source = task {
-        match! Internal.tryPick (TryPickAsync chooser) source with
-        | Some item -> return item
-        | None -> return Internal.raiseNotFound ()
-    }
+    let pickAsync chooser source =
+        Internal.tryPick (TryPickAsync chooser) source
+        |> Task.map (Option.defaultWith Internal.raiseNotFound)
 
-    let find predicate source = task {
-        match! Internal.tryFind (Predicate predicate) source with
-        | Some item -> return item
-        | None -> return Internal.raiseNotFound ()
-    }
+    let find predicate source =
+        Internal.tryFind (Predicate predicate) source
+        |> Task.map (Option.defaultWith Internal.raiseNotFound)
 
+    let findAsync predicate source =
+        Internal.tryFind (PredicateAsync predicate) source
+        |> Task.map (Option.defaultWith Internal.raiseNotFound)
 
-    let findAsync predicate source = task {
-        match! Internal.tryFind (PredicateAsync predicate) source with
-        | Some item -> return item
-        | None -> return Internal.raiseNotFound ()
-    }
+    let findIndex predicate source =
+        Internal.tryFindIndex (Predicate predicate) source
+        |> Task.map (Option.defaultWith Internal.raiseNotFound)
 
-    let findIndex predicate source = task {
-        match! Internal.tryFindIndex (Predicate predicate) source with
-        | Some item -> return item
-        | None -> return Internal.raiseNotFound ()
-    }
-
-    let findIndexAsync predicate source = task {
-        match! Internal.tryFindIndex (PredicateAsync predicate) source with
-        | Some item -> return item
-        | None -> return Internal.raiseNotFound ()
-    }
+    let findIndexAsync predicate source =
+        Internal.tryFindIndex (PredicateAsync predicate) source
+        |> Task.map (Option.defaultWith Internal.raiseNotFound)
 
 
 
     //
-    // zip/unzip etc functions
+    // zip/unzip/fold etc functions
     //
 
     let zip source1 source2 = Internal.zip source1 source2

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -168,6 +168,7 @@ module TaskSeq =
         Internal.checkNonNull (nameof sources) sources
 
         for ts in sources do
+            // no null-check of inner taskseqs, similar to seq
             yield! (ts :> taskSeq<'T>)
     }
 

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -30,6 +30,7 @@ module TaskSeq =
     //
 
     let toList (source: taskSeq<'T>) = [
+        Internal.checkNonNull (nameof source) source
         let e = source.GetAsyncEnumerator(CancellationToken())
 
         try
@@ -40,6 +41,7 @@ module TaskSeq =
     ]
 
     let toArray (source: taskSeq<'T>) = [|
+        Internal.checkNonNull (nameof source) source
         let e = source.GetAsyncEnumerator(CancellationToken())
 
         try
@@ -50,6 +52,7 @@ module TaskSeq =
     |]
 
     let toSeq (source: taskSeq<'T>) = seq {
+        Internal.checkNonNull (nameof source) source
         let e = source.GetAsyncEnumerator(CancellationToken())
 
         try
@@ -74,6 +77,8 @@ module TaskSeq =
     //
 
     let ofArray (source: 'T[]) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             yield c
     }
@@ -84,16 +89,22 @@ module TaskSeq =
     }
 
     let ofSeq (source: 'T seq) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             yield c
     }
 
     let ofResizeArray (source: 'T ResizeArray) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             yield c
     }
 
     let ofTaskSeq (source: #Task<'T> seq) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             let! c = c
             yield c
@@ -106,12 +117,16 @@ module TaskSeq =
     }
 
     let ofTaskArray (source: #Task<'T> array) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             let! c = c
             yield c
     }
 
     let ofAsyncSeq (source: Async<'T> seq) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             let! c = task { return! c }
             yield c
@@ -124,6 +139,8 @@ module TaskSeq =
     }
 
     let ofAsyncArray (source: Async<'T> array) = taskSeq {
+        Internal.checkNonNull (nameof source) source
+
         for c in source do
             let! c = Async.toTask c
             yield c
@@ -148,21 +165,29 @@ module TaskSeq =
         }
 
     let concat (sources: taskSeq<#taskSeq<'T>>) = taskSeq {
+        Internal.checkNonNull (nameof sources) sources
+
         for ts in sources do
             yield! (ts :> taskSeq<'T>)
     }
 
     let append (source1: #taskSeq<'T>) (source2: #taskSeq<'T>) = taskSeq {
+        Internal.checkNonNull (nameof source1) source1
+        Internal.checkNonNull (nameof source2) source2
         yield! (source1 :> IAsyncEnumerable<'T>)
         yield! (source2 :> IAsyncEnumerable<'T>)
     }
 
     let appendSeq (source1: #taskSeq<'T>) (source2: #seq<'T>) = taskSeq {
+        Internal.checkNonNull (nameof source1) source1
+        Internal.checkNonNull (nameof source2) source2
         yield! (source1 :> IAsyncEnumerable<'T>)
         yield! (source2 :> seq<'T>)
     }
 
     let prependSeq (source1: #seq<'T>) (source2: #taskSeq<'T>) = taskSeq {
+        Internal.checkNonNull (nameof source1) source1
+        Internal.checkNonNull (nameof source2) source2
         yield! (source1 :> seq<'T>)
         yield! (source2 :> IAsyncEnumerable<'T>)
     }
@@ -242,6 +267,7 @@ module TaskSeq =
     }
 
     let indexed (source: taskSeq<'T>) = taskSeq {
+        Internal.checkNonNull (nameof source) source
         let mutable i = 0
 
         for x in source do

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -171,25 +171,25 @@ module TaskSeq =
             yield! (ts :> taskSeq<'T>)
     }
 
-    let append (source1: #taskSeq<'T>) (source2: #taskSeq<'T>) = taskSeq {
+    let append (source1: taskSeq<'T>) (source2: taskSeq<'T>) = taskSeq {
         Internal.checkNonNull (nameof source1) source1
         Internal.checkNonNull (nameof source2) source2
-        yield! (source1 :> IAsyncEnumerable<'T>)
-        yield! (source2 :> IAsyncEnumerable<'T>)
+        yield! source1
+        yield! source2
     }
 
-    let appendSeq (source1: #taskSeq<'T>) (source2: #seq<'T>) = taskSeq {
+    let appendSeq (source1: taskSeq<'T>) (source2: seq<'T>) = taskSeq {
         Internal.checkNonNull (nameof source1) source1
         Internal.checkNonNull (nameof source2) source2
-        yield! (source1 :> IAsyncEnumerable<'T>)
-        yield! (source2 :> seq<'T>)
+        yield! source1
+        yield! source2
     }
 
-    let prependSeq (source1: #seq<'T>) (source2: #taskSeq<'T>) = taskSeq {
+    let prependSeq (source1: seq<'T>) (source2: taskSeq<'T>) = taskSeq {
         Internal.checkNonNull (nameof source1) source1
         Internal.checkNonNull (nameof source2) source2
-        yield! (source1 :> seq<'T>)
-        yield! (source2 :> IAsyncEnumerable<'T>)
+        yield! source1
+        yield! source2
     }
 
     //

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -130,7 +130,7 @@ module TaskSeq =
     /// <param name="source2">The second input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the input sequences is null.</exception>
-    val append: source1: #taskSeq<'T> -> source2: #taskSeq<'T> -> taskSeq<'T>
+    val append: source1: taskSeq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
 
     /// <summary>
     /// Concatenates a task sequence <paramref name="source1" /> with a non-async F# <see cref="seq" /> in <paramref name="source2" />
@@ -141,7 +141,7 @@ module TaskSeq =
     /// <param name="source2">The input F# <see cref="seq" /> sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the input sequences is null.</exception>
-    val appendSeq: source1: #taskSeq<'T> -> source2: #seq<'T> -> taskSeq<'T>
+    val appendSeq: source1: taskSeq<'T> -> source2: seq<'T> -> taskSeq<'T>
 
     /// <summary>
     /// Concatenates a non-async F# <see cref="seq" /> in <paramref name="source1" /> with a task sequence in <paramref name="source2" />
@@ -152,7 +152,7 @@ module TaskSeq =
     /// <param name="source2">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the input sequences is null.</exception>
-    val prependSeq: source1: #seq<'T> -> source2: #taskSeq<'T> -> taskSeq<'T>
+    val prependSeq: source1: seq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
 
     /// Returns taskSeq as an array. This function is blocking until the sequence is exhausted and will properly dispose of the resources.
     val toList: source: taskSeq<'T> -> 'T list

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -323,7 +323,7 @@ module TaskSeq =
     val tryItem: index: int -> source: taskSeq<'T> -> Task<'T option>
 
     /// <summary>
-    /// Returns the nth element of the <see cref="taskSeq" />, or <see cref="None" /> if the sequence
+    /// Returns the nth element of the <see cref="taskSeq" />, or raises an exception if the sequence
     /// does not contain enough elements, or if <paramref name="index" /> is negative.
     /// </summary>
     /// <exception cref="ArgumentException">Thrown when the sequence has insufficient length or

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -679,6 +679,8 @@ module internal TaskSeqInternal =
 
     let except itemsToExclude (source: taskSeq<_>) = taskSeq {
         checkNonNull (nameof source) source
+        checkNonNull (nameof itemsToExclude) itemsToExclude
+
         use e = source.GetAsyncEnumerator(CancellationToken())
         let mutable go = true
         let! step = e.MoveNextAsync()
@@ -704,6 +706,8 @@ module internal TaskSeqInternal =
 
     let exceptOfSeq itemsToExclude (source: taskSeq<_>) = taskSeq {
         checkNonNull (nameof source) source
+        checkNonNull (nameof itemsToExclude) itemsToExclude
+
         use e = source.GetAsyncEnumerator(CancellationToken())
         let mutable go = true
         let! step = e.MoveNextAsync()


### PR DESCRIPTION
This PR follows the same principles as F# Core in null-checking:

* Functions are never checked for `null`
* F# Lists are never checked for `null`
* BCL types and interfaces are always checked for `null` (arrays, `IAsyncEnumerable<_>`, `IEnumerable<_>`, `ResizeArray<_>` and the like)

This PR also removes the flexible types for `append/appendSeq/prependSeq` functions, which shouldn't be flexible. We only use flexible types with contravariance (i.e., HOF arguments).

Done:

- [x] Add `checkNonNull` to each function that takes a `taskSeq<'T>` argument
- [x] Same for any other nullable type (see above for when/why)
- [x] Add a null-raising test for each function to prevent the contract ever breaks
- [x] Fix flexible types where applicable (unrelated to null-checks)
