### PR TITLE
Reinstate Disposal

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -7,6 +7,9 @@ Release notes:
     - adds AsyncSeq vs TaskSeq comparison chart, #131
     - removes release-notes.txt from file dependencies, but keep in the package, #138
 
+0.3.1 (unreleased)
+    - fixes not calling Dispose for 'use!' and 'use', #157 (fixed by @bartelink)
+    
 0.3.0
     - internal renames, improved doc comments, signature files for complex types, hide internal-only types, fixes #112.
     - adds support for static TaskLike, allowing the same let! and do! overloads that F# task supports, fixes #110.

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -8,7 +8,7 @@ Release notes:
     - removes release-notes.txt from file dependencies, but keep in the package, #138
 
 0.3.1 (unreleased)
-    - fixes not calling Dispose for 'use!' and 'use', #157 (fixed by @bartelink)
+    - fixes not calling Dispose for 'use!', 'use', or `finally` blocks in `try`...`finally` #157
     
 0.3.0
     - internal renames, improved doc comments, signature files for complex types, hide internal-only types, fixes #112.

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -79,9 +79,8 @@ type TaskSeqStateMachineData<'T>() =
 
     member data.PushDispose(disposer: unit -> Task) =
         if isNull data.disposalStack then
-            data.disposalStack <- null
-
-    //data.disposalStack.Add disposer
+            data.disposalStack <- ResizeArray()
+        data.disposalStack.Add disposer
 
     member data.PopDispose() =
         if not (isNull data.disposalStack) then


### PR DESCRIPTION
Fixes: #157 

https://github.com/jet/equinox and propulsion both depend on the following `taskSeq` features
- disposal via `use!` in task expressions
- logging via `try`/`finally`

This PR reinstates this functionality, which accidentally got disabled in https://github.com/fsprojects/FSharp.Control.TaskSeq/commit/27486f3f1811694de0135b2760d2a1b6840bafc0

(edited in place to refer to the issue)