### PR TITLE
Deprecate `taskSeq<_>` in favor of `TaskSeq<_>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,93 +463,93 @@ The following are the current surface area of the `TaskSeq` utility functions, o
 
 ```f#
 module TaskSeq =
-    val append: source1: taskSeq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
-    val appendSeq: source1: taskSeq<'T> -> source2: seq<'T> -> taskSeq<'T>
-    val box: source: taskSeq<'T> -> taskSeq<obj>
-    val cast: source: taskSeq<obj> -> taskSeq<'T>
-    val choose: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> taskSeq<'U>
-    val chooseAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> taskSeq<'U>
-    val collect: binder: ('T -> #taskSeq<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
-    val collectAsync: binder: ('T -> #Task<'TSeqU>) -> source: taskSeq<'T> -> taskSeq<'U> when 'TSeqU :> taskSeq<'U>
-    val collectSeq: binder: ('T -> #seq<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
-    val collectSeqAsync: binder: ('T -> #Task<'SeqU>) -> source: taskSeq<'T> -> taskSeq<'U> when 'SeqU :> seq<'U>
-    val concat: sources: taskSeq<#taskSeq<'T>> -> taskSeq<'T>
-    val contains<'T when 'T: equality> : value: 'T -> source: taskSeq<'T> -> Task<bool>
-    val delay: generator: (unit -> taskSeq<'T>) -> taskSeq<'T>
-    val empty<'T> : taskSeq<'T>
-    val exactlyOne: source: taskSeq<'T> -> Task<'T>
-    val except<'T when 'T: equality> : itemsToExclude: taskSeq<'T> -> source: taskSeq<'T> -> taskSeq<'T>
-    val exceptOfSeq<'T when 'T: equality> : itemsToExclude: seq<'T> -> source: taskSeq<'T> -> taskSeq<'T>
-    val exists: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<bool>
-    val existsAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<bool>
-    val filter: predicate: ('T -> bool) -> source: taskSeq<'T> -> taskSeq<'T>
-    val filterAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> taskSeq<'T>
-    val find: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<'T>
-    val findAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<'T>
-    val findIndex: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<int>
-    val findIndexAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<int>
-    val fold: folder: ('State -> 'T -> 'State) -> state: 'State -> source: taskSeq<'T> -> Task<'State>
-    val foldAsync: folder: ('State -> 'T -> #Task<'State>) -> state: 'State -> source: taskSeq<'T> -> Task<'State>
-    val head: source: taskSeq<'T> -> Task<'T>
-    val indexed: source: taskSeq<'T> -> taskSeq<int * 'T>
-    val init: count: int -> initializer: (int -> 'T) -> taskSeq<'T>
-    val initAsync: count: int -> initializer: (int -> #Task<'T>) -> taskSeq<'T>
-    val initInfinite: initializer: (int -> 'T) -> taskSeq<'T>
-    val initInfiniteAsync: initializer: (int -> #Task<'T>) -> taskSeq<'T>
-    val isEmpty: source: taskSeq<'T> -> Task<bool>
-    val item: index: int -> source: taskSeq<'T> -> Task<'T>
-    val iter: action: ('T -> unit) -> source: taskSeq<'T> -> Task<unit>
-    val iterAsync: action: ('T -> #Task<unit>) -> source: taskSeq<'T> -> Task<unit>
-    val iteri: action: (int -> 'T -> unit) -> source: taskSeq<'T> -> Task<unit>
-    val iteriAsync: action: (int -> 'T -> #Task<unit>) -> source: taskSeq<'T> -> Task<unit>
-    val last: source: taskSeq<'T> -> Task<'T>
-    val length: source: taskSeq<'T> -> Task<int>
-    val lengthBy: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<int>
-    val lengthByAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<int>
-    val lengthOrMax: max: int -> source: taskSeq<'T> -> Task<int>
-    val map: mapper: ('T -> 'U) -> source: taskSeq<'T> -> taskSeq<'U>
-    val mapAsync: mapper: ('T -> #Task<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
-    val mapi: mapper: (int -> 'T -> 'U) -> source: taskSeq<'T> -> taskSeq<'U>
-    val mapiAsync: mapper: (int -> 'T -> #Task<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
-    val ofArray: source: 'T[] -> taskSeq<'T>
-    val ofAsyncArray: source: Async<'T> array -> taskSeq<'T>
-    val ofAsyncList: source: Async<'T> list -> taskSeq<'T>
-    val ofAsyncSeq: source: seq<Async<'T>> -> taskSeq<'T>
-    val ofList: source: 'T list -> taskSeq<'T>
-    val ofResizeArray: source: ResizeArray<'T> -> taskSeq<'T>
-    val ofSeq: source: seq<'T> -> taskSeq<'T>
-    val ofTaskArray: source: #Task<'T> array -> taskSeq<'T>
-    val ofTaskList: source: #Task<'T> list -> taskSeq<'T>
-    val ofTaskSeq: source: seq<#Task<'T>> -> taskSeq<'T>
-    val pick: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> Task<'U>
-    val pickAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> Task<'U>
-    val prependSeq: source1: seq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
-    val singleton: source: 'T -> taskSeq<'T>
-    val tail: source: taskSeq<'T> -> Task<taskSeq<'T>>
-    val takeWhile: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<taskSeq<'T>>
-    val takeWhileAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<taskSeq<'T>>
-    val takeWhileInclusive: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<taskSeq<'T>>
-    val takeWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<taskSeq<'T>>
-    val toArray: source: taskSeq<'T> -> 'T[]
-    val toArrayAsync: source: taskSeq<'T> -> Task<'T[]>
-    val toIListAsync: source: taskSeq<'T> -> Task<IList<'T>>
-    val toList: source: taskSeq<'T> -> 'T list
-    val toListAsync: source: taskSeq<'T> -> Task<'T list>
-    val toResizeArrayAsync: source: taskSeq<'T> -> Task<ResizeArray<'T>>
-    val toSeq: source: taskSeq<'T> -> seq<'T>
-    val tryExactlyOne: source: taskSeq<'T> -> Task<'T option>
-    val tryFind: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<'T option>
-    val tryFindAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<'T option>
-    val tryFindIndex: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<int option>
-    val tryFindIndexAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<int option>
-    val tryHead: source: taskSeq<'T> -> Task<'T option>
-    val tryItem: index: int -> source: taskSeq<'T> -> Task<'T option>
-    val tryLast: source: taskSeq<'T> -> Task<'T option>
-    val tryPick: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> Task<'U option>
-    val tryPickAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> Task<'U option>
-    val tryTail: source: taskSeq<'T> -> Task<taskSeq<'T> option>
-    val unbox<'U when 'U: struct> : source: taskSeq<obj> -> taskSeq<'U>
-    val zip: source1: taskSeq<'T> -> source2: taskSeq<'U> -> taskSeq<'T * 'U>
+    val append: source1: TaskSeq<'T> -> source2: TaskSeq<'T> -> TaskSeq<'T>
+    val appendSeq: source1: TaskSeq<'T> -> source2: seq<'T> -> TaskSeq<'T>
+    val box: source: TaskSeq<'T> -> TaskSeq<obj>
+    val cast: source: TaskSeq<obj> -> TaskSeq<'T>
+    val choose: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val chooseAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val collect: binder: ('T -> #TaskSeq<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val collectAsync: binder: ('T -> #Task<'TSeqU>) -> source: TaskSeq<'T> -> TaskSeq<'U> when 'TSeqU :> TaskSeq<'U>
+    val collectSeq: binder: ('T -> #seq<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val collectSeqAsync: binder: ('T -> #Task<'SeqU>) -> source: TaskSeq<'T> -> TaskSeq<'U> when 'SeqU :> seq<'U>
+    val concat: sources: TaskSeq<#TaskSeq<'T>> -> TaskSeq<'T>
+    val contains<'T when 'T: equality> : value: 'T -> source: TaskSeq<'T> -> Task<bool>
+    val delay: generator: (unit -> TaskSeq<'T>) -> TaskSeq<'T>
+    val empty<'T> : TaskSeq<'T>
+    val exactlyOne: source: TaskSeq<'T> -> Task<'T>
+    val except<'T when 'T: equality> : itemsToExclude: TaskSeq<'T> -> source: TaskSeq<'T> -> TaskSeq<'T>
+    val exceptOfSeq<'T when 'T: equality> : itemsToExclude: seq<'T> -> source: TaskSeq<'T> -> TaskSeq<'T>
+    val exists: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<bool>
+    val existsAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<bool>
+    val filter: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
+    val filterAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
+    val find: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<'T>
+    val findAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<'T>
+    val findIndex: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<int>
+    val findIndexAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int>
+    val fold: folder: ('State -> 'T -> 'State) -> state: 'State -> source: TaskSeq<'T> -> Task<'State>
+    val foldAsync: folder: ('State -> 'T -> #Task<'State>) -> state: 'State -> source: TaskSeq<'T> -> Task<'State>
+    val head: source: TaskSeq<'T> -> Task<'T>
+    val indexed: source: TaskSeq<'T> -> TaskSeq<int * 'T>
+    val init: count: int -> initializer: (int -> 'T) -> TaskSeq<'T>
+    val initAsync: count: int -> initializer: (int -> #Task<'T>) -> TaskSeq<'T>
+    val initInfinite: initializer: (int -> 'T) -> TaskSeq<'T>
+    val initInfiniteAsync: initializer: (int -> #Task<'T>) -> TaskSeq<'T>
+    val isEmpty: source: TaskSeq<'T> -> Task<bool>
+    val item: index: int -> source: TaskSeq<'T> -> Task<'T>
+    val iter: action: ('T -> unit) -> source: TaskSeq<'T> -> Task<unit>
+    val iterAsync: action: ('T -> #Task<unit>) -> source: TaskSeq<'T> -> Task<unit>
+    val iteri: action: (int -> 'T -> unit) -> source: TaskSeq<'T> -> Task<unit>
+    val iteriAsync: action: (int -> 'T -> #Task<unit>) -> source: TaskSeq<'T> -> Task<unit>
+    val last: source: TaskSeq<'T> -> Task<'T>
+    val length: source: TaskSeq<'T> -> Task<int>
+    val lengthBy: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<int>
+    val lengthByAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int>
+    val lengthOrMax: max: int -> source: TaskSeq<'T> -> Task<int>
+    val map: mapper: ('T -> 'U) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val mapAsync: mapper: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val mapi: mapper: (int -> 'T -> 'U) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val mapiAsync: mapper: (int -> 'T -> #Task<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
+    val ofArray: source: 'T[] -> TaskSeq<'T>
+    val ofAsyncArray: source: Async<'T> array -> TaskSeq<'T>
+    val ofAsyncList: source: Async<'T> list -> TaskSeq<'T>
+    val ofAsyncSeq: source: seq<Async<'T>> -> TaskSeq<'T>
+    val ofList: source: 'T list -> TaskSeq<'T>
+    val ofResizeArray: source: ResizeArray<'T> -> TaskSeq<'T>
+    val ofSeq: source: seq<'T> -> TaskSeq<'T>
+    val ofTaskArray: source: #Task<'T> array -> TaskSeq<'T>
+    val ofTaskList: source: #Task<'T> list -> TaskSeq<'T>
+    val ofTaskSeq: source: seq<#Task<'T>> -> TaskSeq<'T>
+    val pick: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> Task<'U>
+    val pickAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> Task<'U>
+    val prependSeq: source1: seq<'T> -> source2: TaskSeq<'T> -> TaskSeq<'T>
+    val singleton: source: 'T -> TaskSeq<'T>
+    val tail: source: TaskSeq<'T> -> Task<TaskSeq<'T>>
+    val takeWhile: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<TaskSeq<'T>>
+    val takeWhileAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<TaskSeq<'T>>
+    val takeWhileInclusive: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<TaskSeq<'T>>
+    val takeWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<TaskSeq<'T>>
+    val toArray: source: TaskSeq<'T> -> 'T[]
+    val toArrayAsync: source: TaskSeq<'T> -> Task<'T[]>
+    val toIListAsync: source: TaskSeq<'T> -> Task<IList<'T>>
+    val toList: source: TaskSeq<'T> -> 'T list
+    val toListAsync: source: TaskSeq<'T> -> Task<'T list>
+    val toResizeArrayAsync: source: TaskSeq<'T> -> Task<ResizeArray<'T>>
+    val toSeq: source: TaskSeq<'T> -> seq<'T>
+    val tryExactlyOne: source: TaskSeq<'T> -> Task<'T option>
+    val tryFind: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<'T option>
+    val tryFindAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<'T option>
+    val tryFindIndex: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<int option>
+    val tryFindIndexAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int option>
+    val tryHead: source: TaskSeq<'T> -> Task<'T option>
+    val tryItem: index: int -> source: TaskSeq<'T> -> Task<'T option>
+    val tryLast: source: TaskSeq<'T> -> Task<'T option>
+    val tryPick: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> Task<'U option>
+    val tryPickAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> Task<'U option>
+    val tryTail: source: TaskSeq<'T> -> Task<TaskSeq<'T> option>
+    val unbox<'U when 'U: struct> : source: TaskSeq<obj> -> TaskSeq<'U>
+    val zip: source1: TaskSeq<'T> -> source2: TaskSeq<'U> -> TaskSeq<'T * 'U>
 ```
 
 [buildstatus]: https://github.com/fsprojects/FSharp.Control.TaskSeq/actions/workflows/main.yaml

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -2,6 +2,8 @@
 Release notes:
 0.4.x (unreleased)
     - fix documentation, improve tooltips experience, add exception info to every method
+    - 'TaskSeq<'T>' now replaces 'taskSeq<'T>'
+    - DEPRECATED: type alias 'taskSeq<'T>' now raises warning FS0044 in favor of 'TaskSeq<'T>'
     - BINARY INCOMPATIBLE: TaskSeq module members are now static members, source code compatible, #186
 	
 0.4.0-alpha.1

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,9 +1,8 @@
 
 Release notes:
 0.4.x (unreleased)
-    - fix documentation, improve tooltips experience, add exception info to every method
-    - 'TaskSeq<'T>' now replaces 'taskSeq<'T>'
-    - DEPRECATED: type alias 'taskSeq<'T>' now raises warning FS0044 in favor of 'TaskSeq<'T>'
+    - overhaul all doc comments, add exceptions info, improve tooltips experience, #136
+    - DEPRECATED: type 'TaskSeq<'T>' now replaces 'taskSeq<'T>', the latter deprecated FS0044, #187
     - BINARY INCOMPATIBLE: TaskSeq module members are now static members, source code compatible, #186
 	
 0.4.0-alpha.1

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Tests.CE.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Tests.CE.fs
@@ -11,7 +11,7 @@ open FSharp.Control
 let ``CE taskSeq using yield! with null`` () = task {
     let ts = taskSeq {
         yield! Gen.sideEffectTaskSeq 10
-        yield! (null: taskSeq<int>)
+        yield! (null: TaskSeq<int>)
     }
 
     fun () -> TaskSeq.toList ts

--- a/src/FSharp.Control.TaskSeq/AsyncExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/AsyncExtensions.fs
@@ -6,7 +6,7 @@ module AsyncExtensions =
     // Add asynchronous for loop to the 'async' computation builder
     type Microsoft.FSharp.Control.AsyncBuilder with
 
-        member _.For(source: taskSeq<'T>, action: 'T -> Async<unit>) =
+        member _.For(source: TaskSeq<'T>, action: 'T -> Async<unit>) =
             source
             |> TaskSeq.iterAsync (action >> Async.StartAsTask)
             |> Async.AwaitTask

--- a/src/FSharp.Control.TaskSeq/AsyncExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/AsyncExtensions.fsi
@@ -8,4 +8,4 @@ module AsyncExtensions =
         /// <summary>
         /// Inside <see cref="async" />, iterate over all values of a <see cref="taskSeq" />.
         /// </summary>
-        member For: source: taskSeq<'T> * action: ('T -> Async<unit>) -> Async<unit>
+        member For: source: TaskSeq<'T> * action: ('T -> Async<unit>) -> Async<unit>

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fs
@@ -56,7 +56,7 @@ module TaskExtensions =
                         false)
             )
 
-        member inline this.For(source: taskSeq<'T>, body: 'T -> TaskCode<_, unit>) : TaskCode<_, unit> =
+        member inline this.For(source: TaskSeq<'T>, body: 'T -> TaskCode<_, unit>) : TaskCode<_, unit> =
             TaskCode<'TOverall, unit>(fun sm ->
                 this
                     .Using(

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
@@ -10,4 +10,4 @@ module TaskExtensions =
         /// <summary>
         /// Inside <see cref="task" />, iterate over all values of a <see cref="taskSeq" />.
         /// </summary>
-        member inline For: source: taskSeq<'T> * body: ('T -> TaskCode<'TOverall, unit>) -> TaskCode<'TOverall, unit>
+        member inline For: source: TaskSeq<'T> * body: ('T -> TaskCode<'TOverall, unit>) -> TaskCode<'TOverall, unit>

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -38,7 +38,7 @@ type TaskSeq private () =
     // Convert 'ToXXX' functions
     //
 
-    static member toList(source: taskSeq<'T>) = [
+    static member toList(source: TaskSeq<'T>) = [
         Internal.checkNonNull (nameof source) source
         let e = source.GetAsyncEnumerator(CancellationToken())
 
@@ -49,7 +49,7 @@ type TaskSeq private () =
             e.DisposeAsync().AsTask().Wait()
     ]
 
-    static member toArray(source: taskSeq<'T>) = [|
+    static member toArray(source: TaskSeq<'T>) = [|
         Internal.checkNonNull (nameof source) source
         let e = source.GetAsyncEnumerator(CancellationToken())
 
@@ -60,7 +60,7 @@ type TaskSeq private () =
             e.DisposeAsync().AsTask().Wait()
     |]
 
-    static member toSeq(source: taskSeq<'T>) =
+    static member toSeq(source: TaskSeq<'T>) =
         Internal.checkNonNull (nameof source) source
 
         seq {
@@ -178,21 +178,21 @@ type TaskSeq private () =
     static member initAsync count initializer = Internal.init (Some count) (InitActionAsync initializer)
     static member initInfiniteAsync initializer = Internal.init None (InitActionAsync initializer)
 
-    static member delay(generator: unit -> taskSeq<'T>) =
+    static member delay(generator: unit -> TaskSeq<'T>) =
         { new IAsyncEnumerable<'T> with
             member _.GetAsyncEnumerator(ct) = generator().GetAsyncEnumerator(ct)
         }
 
-    static member concat(sources: taskSeq<#taskSeq<'T>>) =
+    static member concat(sources: TaskSeq<#TaskSeq<'T>>) =
         Internal.checkNonNull (nameof sources) sources
 
         taskSeq {
             for ts in sources do
                 // no null-check of inner taskseqs, similar to seq
-                yield! (ts :> taskSeq<'T>)
+                yield! (ts :> TaskSeq<'T>)
         }
 
-    static member append (source1: taskSeq<'T>) (source2: taskSeq<'T>) =
+    static member append (source1: TaskSeq<'T>) (source2: TaskSeq<'T>) =
         Internal.checkNonNull (nameof source1) source1
         Internal.checkNonNull (nameof source2) source2
 
@@ -201,7 +201,7 @@ type TaskSeq private () =
             yield! source2
         }
 
-    static member appendSeq (source1: taskSeq<'T>) (source2: seq<'T>) =
+    static member appendSeq (source1: TaskSeq<'T>) (source2: seq<'T>) =
         Internal.checkNonNull (nameof source1) source1
         Internal.checkNonNull (nameof source2) source2
 
@@ -210,7 +210,7 @@ type TaskSeq private () =
             yield! source2
         }
 
-    static member prependSeq (source1: seq<'T>) (source2: taskSeq<'T>) =
+    static member prependSeq (source1: seq<'T>) (source2: TaskSeq<'T>) =
         Internal.checkNonNull (nameof source1) source1
         Internal.checkNonNull (nameof source2) source2
 
@@ -223,9 +223,9 @@ type TaskSeq private () =
     // iter/map/collect functions
     //
 
-    static member cast source : taskSeq<'T> = Internal.map (SimpleAction(fun (x: obj) -> x :?> 'T)) source
+    static member cast source : TaskSeq<'T> = Internal.map (SimpleAction(fun (x: obj) -> x :?> 'T)) source
     static member box source = Internal.map (SimpleAction box) source
-    static member unbox<'U when 'U: struct>(source: taskSeq<obj>) : taskSeq<'U> = Internal.map (SimpleAction unbox) source
+    static member unbox<'U when 'U: struct>(source: TaskSeq<obj>) : TaskSeq<'U> = Internal.map (SimpleAction unbox) source
     static member iter action source = Internal.iter (SimpleAction action) source
     static member iteri action source = Internal.iter (CountableAction action) source
     static member iterAsync action source = Internal.iter (AsyncSimpleAction action) source
@@ -234,10 +234,10 @@ type TaskSeq private () =
     static member mapi (mapper: int -> 'T -> 'U) source = Internal.map (CountableAction mapper) source
     static member mapAsync mapper source = Internal.map (AsyncSimpleAction mapper) source
     static member mapiAsync mapper source = Internal.map (AsyncCountableAction mapper) source
-    static member collect (binder: 'T -> #taskSeq<'U>) source = Internal.collect binder source
+    static member collect (binder: 'T -> #TaskSeq<'U>) source = Internal.collect binder source
     static member collectSeq (binder: 'T -> #seq<'U>) source = Internal.collectSeq binder source
-    static member collectAsync (binder: 'T -> #Task<#taskSeq<'U>>) source : taskSeq<'U> = Internal.collectAsync binder source
-    static member collectSeqAsync (binder: 'T -> #Task<#seq<'U>>) source : taskSeq<'U> = Internal.collectSeqAsync binder source
+    static member collectAsync (binder: 'T -> #Task<#TaskSeq<'U>>) source : TaskSeq<'U> = Internal.collectAsync binder source
+    static member collectSeqAsync (binder: 'T -> #Task<#seq<'U>>) source : TaskSeq<'U> = Internal.collectSeqAsync binder source
 
     //
     // choosers, pickers and the like
@@ -276,7 +276,7 @@ type TaskSeq private () =
         Internal.tryExactlyOne source
         |> Task.map (Option.defaultWith (fun () -> invalidArg (nameof source) "The input sequence contains more than one element."))
 
-    static member indexed(source: taskSeq<'T>) =
+    static member indexed(source: TaskSeq<'T>) =
         Internal.checkNonNull (nameof source) source
 
         taskSeq {

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -9,7 +9,7 @@ open System.Threading.Tasks
 module TaskSeqExtensions =
     module TaskSeq =
         /// Initialize an empty task sequence.
-        val empty<'T> : taskSeq<'T>
+        val empty<'T> : TaskSeq<'T>
 
 [<Sealed; AbstractClass>]
 type TaskSeq =
@@ -19,7 +19,7 @@ type TaskSeq =
     /// </summary>
     ///
     /// <param name="value">The input item to use as the single item of the task sequence.</param>
-    static member singleton: value: 'T -> taskSeq<'T>
+    static member singleton: value: 'T -> TaskSeq<'T>
 
     /// <summary>
     /// Returns <see cref="true" /> if the task sequence contains no elements, <see cref="false" /> otherwise.
@@ -27,7 +27,7 @@ type TaskSeq =
     ///
     /// <param name="source">The input task sequence.</param>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member isEmpty: source: taskSeq<'T> -> Task<bool>
+    static member isEmpty: source: TaskSeq<'T> -> Task<bool>
 
     /// <summary>
     /// Returns the length of the sequence. This operation requires the whole sequence to be evaluated and
@@ -36,7 +36,7 @@ type TaskSeq =
     ///
     /// <param name="source">The input task sequence.</param>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member length: source: taskSeq<'T> -> Task<int>
+    static member length: source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
     /// Returns the length of the sequence, or <paramref name="max" />, whichever comes first. This operation requires the task sequence
@@ -47,7 +47,7 @@ type TaskSeq =
     /// <param name="max">Limit at which to stop evaluating source items for finding the length.</param>
     /// <param name="source">The input task sequence.</param>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member lengthOrMax: max: int -> source: taskSeq<'T> -> Task<int>
+    static member lengthOrMax: max: int -> source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
     /// Returns the length of the sequence of all items for which the <paramref name="predicate" /> returns true.
@@ -58,7 +58,7 @@ type TaskSeq =
     /// <param name="predicate">A function to test whether an item in the input sequence should be included in the count.</param>
     /// <param name="source">The input task sequence.</param>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member lengthBy: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<int>
+    static member lengthBy: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
     /// Returns the length of the sequence of all items for which the <paramref name="predicate" /> returns true.
@@ -69,7 +69,7 @@ type TaskSeq =
     /// <param name="predicate">A function to test whether an item in the input sequence should be included in the count.</param>
     /// <param name="source">The input task sequence.</param>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member lengthByAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<int>
+    static member lengthByAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
     /// Returns a task sequence that is given by the delayed specification of a task sequence.
@@ -77,7 +77,7 @@ type TaskSeq =
     ///
     /// <param name="generator">The generating function for the task sequence.</param>
     /// <returns>The generated task sequence.</returns>
-    static member delay: generator: (unit -> taskSeq<'T>) -> taskSeq<'T>
+    static member delay: generator: (unit -> TaskSeq<'T>) -> TaskSeq<'T>
 
     /// <summary>
     /// Generates a new task sequence which, when iterated, will return successive elements by calling the given function
@@ -92,7 +92,7 @@ type TaskSeq =
     /// <param name="initializer">A function that generates an item in the sequence from a given index.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:System.ArgumentException">Thrown when count is negative.</exception>
-    static member init: count: int -> initializer: (int -> 'T) -> taskSeq<'T>
+    static member init: count: int -> initializer: (int -> 'T) -> TaskSeq<'T>
 
     /// <summary>
     /// Generates a new task sequence which, when iterated, will return successive elements by calling the given function
@@ -107,7 +107,7 @@ type TaskSeq =
     /// <param name="initializer">A function that generates an item in the sequence from a given index.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:System.ArgumentException">Thrown when count is negative.</exception>
-    static member initAsync: count: int -> initializer: (int -> #Task<'T>) -> taskSeq<'T>
+    static member initAsync: count: int -> initializer: (int -> #Task<'T>) -> TaskSeq<'T>
 
     /// <summary>
     /// Generates a new task sequence which, when iterated, will return successive elements by calling the given function
@@ -121,7 +121,7 @@ type TaskSeq =
     ///
     /// <param name="initializer">A function that generates an item in the sequence from a given index.</param>
     /// <returns>The resulting task sequence.</returns>
-    static member initInfinite: initializer: (int -> 'T) -> taskSeq<'T>
+    static member initInfinite: initializer: (int -> 'T) -> TaskSeq<'T>
 
     /// <summary>
     /// Generates a new task sequence which, when iterated, will return successive elements by calling the given function
@@ -135,7 +135,7 @@ type TaskSeq =
     ///
     /// <param name="initializer">A function that generates an item in the sequence from a given index.</param>
     /// <returns>The resulting task sequence.</returns>
-    static member initInfiniteAsync: initializer: (int -> #Task<'T>) -> taskSeq<'T>
+    static member initInfiniteAsync: initializer: (int -> #Task<'T>) -> TaskSeq<'T>
 
     /// <summary>
     /// Combines the given task sequence of task sequences and concatenates them end-to-end, to form a
@@ -145,7 +145,7 @@ type TaskSeq =
     /// <param name="sources">The input task-sequence-of-task-sequences.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence of task sequences is null.</exception>
-    static member concat: sources: taskSeq<#taskSeq<'T>> -> taskSeq<'T>
+    static member concat: sources: TaskSeq<#TaskSeq<'T>> -> TaskSeq<'T>
 
     /// <summary>
     /// Concatenates task sequences <paramref name="source1" /> and <paramref name="source2" /> in order as a single
@@ -156,7 +156,7 @@ type TaskSeq =
     /// <param name="source2">The second input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the input task sequences is null.</exception>
-    static member append: source1: taskSeq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
+    static member append: source1: TaskSeq<'T> -> source2: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Concatenates a task sequence <paramref name="source1" /> with a non-async F# <see cref="seq" /> in <paramref name="source2" />
@@ -167,7 +167,7 @@ type TaskSeq =
     /// <param name="source2">The input F# <see cref="seq" /> sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the input sequences is null.</exception>
-    static member appendSeq: source1: taskSeq<'T> -> source2: seq<'T> -> taskSeq<'T>
+    static member appendSeq: source1: TaskSeq<'T> -> source2: seq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Concatenates a non-async F# <see cref="seq" /> in <paramref name="source1" /> with a task sequence in <paramref name="source2" />
@@ -178,7 +178,7 @@ type TaskSeq =
     /// <param name="source2">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the input sequences is null.</exception>
-    static member prependSeq: source1: seq<'T> -> source2: taskSeq<'T> -> taskSeq<'T>
+    static member prependSeq: source1: seq<'T> -> source2: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Builds an F# <see cref="list" /> from the input task sequence in <paramref name="source" />.
@@ -188,7 +188,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting list.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toList: source: taskSeq<'T> -> 'T list
+    static member toList: source: TaskSeq<'T> -> 'T list
 
     /// <summary>
     /// Builds an <see cref="array" /> from the input task sequence in <paramref name="source" />.
@@ -198,7 +198,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting array.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toArray: source: taskSeq<'T> -> 'T[]
+    static member toArray: source: TaskSeq<'T> -> 'T[]
 
     /// <summary>
     /// Views the task sequence in <paramref name="source" /> as an F# <see cref="seq" />, that is, an
@@ -210,7 +210,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toSeq: source: taskSeq<'T> -> seq<'T>
+    static member toSeq: source: TaskSeq<'T> -> seq<'T>
 
     /// <summary>
     /// Builds an <see cref="array" /> asynchronously from the input task sequence.
@@ -220,7 +220,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting array.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toArrayAsync: source: taskSeq<'T> -> Task<'T[]>
+    static member toArrayAsync: source: TaskSeq<'T> -> Task<'T[]>
 
     /// <summary>
     /// Builds an F# <see cref="list" /> asynchronously from the input task sequence.
@@ -230,7 +230,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting list.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toListAsync: source: taskSeq<'T> -> Task<'T list>
+    static member toListAsync: source: TaskSeq<'T> -> Task<'T list>
 
     /// <summary>
     /// Gathers items into a ResizeArray (see <see cref="T:System.Collections.Generic.List&lt;_>" />) asynchronously from the input task sequence.
@@ -240,7 +240,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting resizable array.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toResizeArrayAsync: source: taskSeq<'T> -> Task<ResizeArray<'T>>
+    static member toResizeArrayAsync: source: TaskSeq<'T> -> Task<ResizeArray<'T>>
 
     /// <summary>
     /// Builds an <see cref="IList&lt;'T>" /> asynchronously from the input task sequence.
@@ -250,7 +250,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting IList interface.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member toIListAsync: source: taskSeq<'T> -> Task<IList<'T>>
+    static member toIListAsync: source: TaskSeq<'T> -> Task<IList<'T>>
 
     /// <summary>
     /// Views the given <see cref="array" /> as a task sequence, that is, as an <see cref="IAsyncEnumerable&lt;'T>" />.
@@ -259,7 +259,7 @@ type TaskSeq =
     /// <param name="source">The input array.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input array is null.</exception>
-    static member ofArray: source: 'T[] -> taskSeq<'T>
+    static member ofArray: source: 'T[] -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="list" /> as a task sequence, that is, as an <see cref="IAsyncEnumerable&lt;'T>" />.
@@ -267,7 +267,7 @@ type TaskSeq =
     ///
     /// <param name="source">The input list.</param>
     /// <returns>The resulting task sequence.</returns>
-    static member ofList: source: 'T list -> taskSeq<'T>
+    static member ofList: source: 'T list -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="seq" /> as a task sequence, that is, as an <see cref="IAsyncEnumerable&lt;'T>" />.
@@ -276,7 +276,7 @@ type TaskSeq =
     /// <param name="source">The input sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member ofSeq: source: seq<'T> -> taskSeq<'T>
+    static member ofSeq: source: seq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given resizable array as a task sequence, that is, as an <see cref="IAsyncEnumerable&lt;'T>" />.
@@ -285,7 +285,7 @@ type TaskSeq =
     /// <param name="source">The input resize array.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input resize array is null.</exception>
-    static member ofResizeArray: source: ResizeArray<'T> -> taskSeq<'T>
+    static member ofResizeArray: source: ResizeArray<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="seq" /> of <see cref="Task" />s as a task sequence, that is, as an
@@ -298,7 +298,7 @@ type TaskSeq =
     /// <param name="source">The input sequence-of-tasks.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member ofTaskSeq: source: seq<#Task<'T>> -> taskSeq<'T>
+    static member ofTaskSeq: source: seq<#Task<'T>> -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="list" /> of <see cref="Task" />s as a task sequence, that is, as an
@@ -311,7 +311,7 @@ type TaskSeq =
     ///
     /// <param name="source">The input list-of-tasks.</param>
     /// <returns>The resulting task sequence.</returns>
-    static member ofTaskList: source: #Task<'T> list -> taskSeq<'T>
+    static member ofTaskList: source: #Task<'T> list -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="array" /> of <see cref="Task" />s as a task sequence, that is, as an
@@ -325,7 +325,7 @@ type TaskSeq =
     /// <param name="source">The input array-of-tasks.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input array is null.</exception>
-    static member ofTaskArray: source: #Task<'T> array -> taskSeq<'T>
+    static member ofTaskArray: source: #Task<'T> array -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="seq" /> of <see cref="Async" />s as a task sequence, that is, as an
@@ -338,7 +338,7 @@ type TaskSeq =
     /// <param name="source">The input sequence-of-asyncs.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member ofAsyncSeq: source: seq<Async<'T>> -> taskSeq<'T>
+    static member ofAsyncSeq: source: seq<Async<'T>> -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="list" /> of <see cref="Async" />s as a task sequence, that is, as an
@@ -350,7 +350,7 @@ type TaskSeq =
     ///
     /// <param name="source">The input list-of-asyncs.</param>
     /// <returns>The resulting task sequence.</returns>
-    static member ofAsyncList: source: Async<'T> list -> taskSeq<'T>
+    static member ofAsyncList: source: Async<'T> list -> TaskSeq<'T>
 
     /// <summary>
     /// Views the given <see cref="array" /> of <see cref="Async" />s as a task sequence, that is, as an
@@ -363,7 +363,7 @@ type TaskSeq =
     /// <param name="source">The input array-of-asyncs.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member ofAsyncArray: source: Async<'T> array -> taskSeq<'T>
+    static member ofAsyncArray: source: Async<'T> array -> TaskSeq<'T>
 
     /// <summary>
     /// Views each item in the input task sequence as <see cref="obj" />, boxing value types.
@@ -372,7 +372,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member box: source: taskSeq<'T> -> taskSeq<obj>
+    static member box: source: TaskSeq<'T> -> TaskSeq<obj>
 
     /// <summary>
     /// Unboxes to the target type <see cref="'U" /> each item in the input task sequence.
@@ -383,7 +383,7 @@ type TaskSeq =
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="InvalidCastException">Thrown when the function is unable to cast an item to the target type.</exception>
-    static member unbox<'U when 'U: struct> : source: taskSeq<obj> -> taskSeq<'U>
+    static member unbox<'U when 'U: struct> : source: TaskSeq<obj> -> TaskSeq<'U>
 
     /// <summary>
     /// Casts each item in the untyped input task sequence. If the input sequence contains value types
@@ -394,7 +394,7 @@ type TaskSeq =
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="InvalidCastException">Thrown when the function is unable to cast an item to the target type.</exception>
-    static member cast: source: taskSeq<obj> -> taskSeq<'U>
+    static member cast: source: TaskSeq<obj> -> TaskSeq<'U>
 
     /// <summary>
     /// Iterates over the input task sequence, applying the <paramref name="action" /> function to each item.
@@ -405,7 +405,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>A <see cref="unit" /> <see cref="task" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member iter: action: ('T -> unit) -> source: taskSeq<'T> -> Task<unit>
+    static member iter: action: ('T -> unit) -> source: TaskSeq<'T> -> Task<unit>
 
     /// <summary>
     /// Iterates over the input task sequence, applying the <paramref name="action" /> function to each item,
@@ -417,7 +417,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>A <see cref="unit" /> <see cref="task" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member iteri: action: (int -> 'T -> unit) -> source: taskSeq<'T> -> Task<unit>
+    static member iteri: action: (int -> 'T -> unit) -> source: TaskSeq<'T> -> Task<unit>
 
     /// <summary>
     /// Iterates over the input task sequence, applying the asynchronous <paramref name="action" /> function to each item.
@@ -428,7 +428,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>A <see cref="unit" /> <see cref="task" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member iterAsync: action: ('T -> #Task<unit>) -> source: taskSeq<'T> -> Task<unit>
+    static member iterAsync: action: ('T -> #Task<unit>) -> source: TaskSeq<'T> -> Task<unit>
 
     /// <summary>
     /// Iterates over the input task sequence, applying the asynchronous <paramref name="action" /> function to each item,
@@ -440,7 +440,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>A <see cref="unit" /> <see cref="task" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
-    static member iteriAsync: action: (int -> 'T -> #Task<unit>) -> source: taskSeq<'T> -> Task<unit>
+    static member iteriAsync: action: (int -> 'T -> #Task<unit>) -> source: TaskSeq<'T> -> Task<unit>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the corresponding elements of the input task
@@ -451,7 +451,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence of tuples.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member indexed: source: taskSeq<'T> -> taskSeq<int * 'T>
+    static member indexed: source: TaskSeq<'T> -> TaskSeq<int * 'T>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the <paramref name="action" />
@@ -465,7 +465,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member map: mapper: ('T -> 'U) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member map: mapper: ('T -> 'U) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the <paramref name="action" />
@@ -480,7 +480,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member mapi: mapper: (int -> 'T -> 'U) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member mapi: mapper: (int -> 'T -> 'U) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the asynchronous <paramref name="action" />
@@ -494,7 +494,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member mapAsync: mapper: ('T -> #Task<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member mapAsync: mapper: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the asynchronous <paramref name="action" />
@@ -509,7 +509,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member mapiAsync: mapper: (int -> 'T -> #Task<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member mapiAsync: mapper: (int -> 'T -> #Task<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the <paramref name="binder" />
@@ -524,7 +524,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting concatenation of all returned task sequences.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member collect: binder: ('T -> #taskSeq<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member collect: binder: ('T -> #TaskSeq<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the <paramref name="binder" />
@@ -539,7 +539,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting concatenation of all returned task sequences.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member collectSeq: binder: ('T -> #seq<'U>) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member collectSeq: binder: ('T -> #seq<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the asynchronous <paramref name="binder" />
@@ -555,7 +555,7 @@ type TaskSeq =
     /// <returns>The resulting concatenation of all returned task sequences.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     static member collectAsync:
-        binder: ('T -> #Task<'TSeqU>) -> source: taskSeq<'T> -> taskSeq<'U> when 'TSeqU :> taskSeq<'U>
+        binder: ('T -> #Task<'TSeqU>) -> source: TaskSeq<'T> -> TaskSeq<'U> when 'TSeqU :> TaskSeq<'U>
 
     /// <summary>
     /// Builds a new task sequence whose elements are the results of applying the asynchronous <paramref name="binder" />
@@ -571,7 +571,7 @@ type TaskSeq =
     /// <returns>The resulting concatenation of all returned task sequences.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     static member collectSeqAsync:
-        binder: ('T -> #Task<'SeqU>) -> source: taskSeq<'T> -> taskSeq<'U> when 'SeqU :> seq<'U>
+        binder: ('T -> #Task<'SeqU>) -> source: TaskSeq<'T> -> TaskSeq<'U> when 'SeqU :> seq<'U>
 
     /// <summary>
     /// Returns the first element of the input task sequence given by <paramref name="source" />,
@@ -581,7 +581,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The first element of the task sequence, or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryHead: source: taskSeq<'T> -> Task<'T option>
+    static member tryHead: source: TaskSeq<'T> -> Task<'T option>
 
     /// <summary>
     /// Returns the first element of the input task sequence given by <paramref name="source" />.
@@ -591,7 +591,7 @@ type TaskSeq =
     /// <returns>The first element of the task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:ArgumentException">Thrown when the task sequence is empty.</exception>
-    static member head: source: taskSeq<'T> -> Task<'T>
+    static member head: source: TaskSeq<'T> -> Task<'T>
 
     /// <summary>
     /// Returns the whole input task sequence given by <paramref name="source" />, minus its first element,
@@ -601,7 +601,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The input task sequence minus the first element, or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryTail: source: taskSeq<'T> -> Task<taskSeq<'T> option>
+    static member tryTail: source: TaskSeq<'T> -> Task<TaskSeq<'T> option>
 
     /// <summary>
     /// Returns the whole task sequence from <paramref name="source" />, minus its first element.
@@ -611,7 +611,7 @@ type TaskSeq =
     /// <returns>The input task sequence minus the first element.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:ArgumentException">Thrown when the task sequence is empty.</exception>
-    static member tail: source: taskSeq<'T> -> Task<taskSeq<'T>>
+    static member tail: source: TaskSeq<'T> -> Task<TaskSeq<'T>>
 
     /// <summary>
     /// Returns the last element of the input task sequence given by <paramref name="source" />,
@@ -621,7 +621,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The last element of the task sequence, or None.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryLast: source: taskSeq<'T> -> Task<'T option>
+    static member tryLast: source: TaskSeq<'T> -> Task<'T option>
 
     /// <summary>
     /// Returns the last element of the input task sequence given by <paramref name="source" />.
@@ -631,7 +631,7 @@ type TaskSeq =
     /// <returns>The last element of the task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:ArgumentException">Thrown when the task sequence is empty.</exception>
-    static member last: source: taskSeq<'T> -> Task<'T>
+    static member last: source: TaskSeq<'T> -> Task<'T>
 
     /// <summary>
     /// Returns the nth element of the input task sequence given by <paramref name="source" />,
@@ -642,7 +642,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The nth element of the task sequence, or None if it doesn't exist.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryItem: index: int -> source: taskSeq<'T> -> Task<'T option>
+    static member tryItem: index: int -> source: TaskSeq<'T> -> Task<'T option>
 
     /// <summary>
     /// Returns the nth element of the input task sequence given by <paramref name="source" />,
@@ -654,7 +654,7 @@ type TaskSeq =
     /// <returns>The nth element of the task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:ArgumentException">Thrown when the sequence has insufficient length or <paramref name="index" /> is negative.</exception>
-    static member item: index: int -> source: taskSeq<'T> -> Task<'T>
+    static member item: index: int -> source: TaskSeq<'T> -> Task<'T>
 
     /// <summary>
     /// Returns the only element of the task sequence, or <see cref="None" /> if the sequence is empty of
@@ -664,7 +664,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The only element of the singleton task sequence, or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryExactlyOne: source: taskSeq<'T> -> Task<'T option>
+    static member tryExactlyOne: source: TaskSeq<'T> -> Task<'T option>
 
     /// <summary>
     /// Returns the only element of the task sequence.
@@ -674,7 +674,7 @@ type TaskSeq =
     /// <returns>The only element of the singleton task sequence, or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:ArgumentException">Thrown when the input task sequence does not contain precisely one element.</exception>
-    static member exactlyOne: source: taskSeq<'T> -> Task<'T>
+    static member exactlyOne: source: TaskSeq<'T> -> Task<'T>
 
     /// <summary>
     /// Applies the given function <paramref name="chooser" /> to each element of the task sequence. Returns
@@ -686,7 +686,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member choose: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member choose: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Applies the given asynchronous function <paramref name="chooser" /> to each element of the task sequence.
@@ -699,7 +699,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member chooseAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> taskSeq<'U>
+    static member chooseAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Returns a new task sequence containing only the elements of the collection
@@ -711,7 +711,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member filter: predicate: ('T -> bool) -> source: taskSeq<'T> -> taskSeq<'T>
+    static member filter: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Returns a new task sequence containing only the elements of the input sequence
@@ -723,7 +723,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member filterAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> taskSeq<'T>
+    static member filterAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Returns a task sequence that, when iterated, yields elements of the underlying sequence while the
@@ -737,7 +737,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member takeWhile: predicate: ('T -> bool) -> source: taskSeq<'T> -> taskSeq<'T>
+    static member takeWhile: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Returns a sequence that, when iterated, yields elements of the underlying sequence while the
@@ -751,7 +751,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member takeWhileAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> taskSeq<'T>
+    static member takeWhileAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Returns a sequence that, when iterated, yields elements of the underlying sequence until the given
@@ -765,7 +765,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member takeWhileInclusive: predicate: ('T -> bool) -> source: taskSeq<'T> -> taskSeq<'T>
+    static member takeWhileInclusive: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Returns a sequence that, when iterated, yields elements of the underlying sequence until the given
@@ -779,7 +779,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member takeWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> taskSeq<'T>
+    static member takeWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Applies the given function <paramref name="chooser" /> to successive elements, returning the first result where
@@ -790,7 +790,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The chosen element or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryPick: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> Task<'U option>
+    static member tryPick: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> Task<'U option>
 
     /// <summary>
     /// Applies the given asynchronous function <paramref name="chooser" /> to successive elements, returning the first result where
@@ -801,7 +801,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The chosen element or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryPickAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> Task<'U option>
+    static member tryPickAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> Task<'U option>
 
     /// <summary>
     /// Returns the first element for which the given function <paramref name="predicate" /> returns
@@ -813,7 +813,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The found element or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryFind: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<'T option>
+    static member tryFind: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<'T option>
 
     /// <summary>
     /// Returns the first element for which the given asynchronous function <paramref name="predicate" /> returns
@@ -825,7 +825,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The found element or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryFindAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<'T option>
+    static member tryFindAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<'T option>
 
     /// <summary>
     /// Returns the index, starting from zero, for which the given function <paramref name="predicate" /> returns
@@ -837,7 +837,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The found element or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryFindIndex: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<int option>
+    static member tryFindIndex: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<int option>
 
     /// <summary>
     /// Returns the index, starting from zero, for which the given asynchronous function <paramref name="predicate" /> returns
@@ -849,7 +849,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns>The found element or <see cref="None" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member tryFindIndexAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<int option>
+    static member tryFindIndexAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int option>
 
     /// <summary>
     /// Applies the given function <paramref name="chooser" /> to successive elements, returning the first result where
@@ -862,7 +862,7 @@ type TaskSeq =
     /// <returns>The selected element.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:KeyNotFoundException">Thrown when every item of the sequence evaluates to <see cref="None" /> when the given function is applied.</exception>
-    static member pick: chooser: ('T -> 'U option) -> source: taskSeq<'T> -> Task<'U>
+    static member pick: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> Task<'U>
 
     /// <summary>
     /// Applies the given asynchronous function <paramref name="chooser" /> to successive elements, returning the first result where
@@ -875,7 +875,7 @@ type TaskSeq =
     /// <returns>The selected element.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:KeyNotFoundException">Thrown when every item of the sequence evaluates to <see cref="None" /> when the given function is applied.</exception>
-    static member pickAsync: chooser: ('T -> #Task<'U option>) -> source: taskSeq<'T> -> Task<'U>
+    static member pickAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> Task<'U>
 
     /// <summary>
     /// Returns the first element for which the given function <paramref name="predicate" /> returns <see cref="true" />.
@@ -888,7 +888,7 @@ type TaskSeq =
     /// <returns>The first element for which the predicate returns <see cref="true" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:KeyNotFoundException">Thrown if no element returns <see cref="true" /> when evaluated by the <paramref name="predicate" /> function.</exception>
-    static member find: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<'T>
+    static member find: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<'T>
 
     /// <summary>
     /// Returns the first element for which the given asynchronous function <paramref name="predicate" /> returns <see cref="true" />.
@@ -901,7 +901,7 @@ type TaskSeq =
     /// <returns>The first element for which the predicate returns <see cref="true" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:KeyNotFoundException">Thrown if no element returns <see cref="true" /> when evaluated by the <paramref name="predicate" /> function.</exception>
-    static member findAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<'T>
+    static member findAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<'T>
 
     /// <summary>
     /// Returns the index, starting from zero, of the first element for which the given function <paramref name="predicate" />
@@ -914,7 +914,7 @@ type TaskSeq =
     /// <returns>The index for which the predicate returns <see cref="true" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:KeyNotFoundException">Thrown if no element returns <see cref="true" /> when evaluated by the <paramref name="predicate" /> function.</exception>
-    static member findIndex: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<int>
+    static member findIndex: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
     /// Returns the index, starting from zero, of the first element for which the given function <paramref name="predicate" />
@@ -927,7 +927,7 @@ type TaskSeq =
     /// <returns>The index for which the predicate returns <see cref="true" />.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     /// <exception cref="T:KeyNotFoundException">Thrown if no element returns <see cref="true" /> when evaluated by the <paramref name="predicate" /> function.</exception>
-    static member findIndexAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<int>
+    static member findIndexAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
     /// Tests if the sequence contains the specified element. Returns <see cref="true" />
@@ -939,7 +939,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns><see cref="True" /> if the input sequence contains the specified element; <see cref="false" /> otherwise.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member contains<'T when 'T: equality> : value: 'T -> source: taskSeq<'T> -> Task<bool>
+    static member contains<'T when 'T: equality> : value: 'T -> source: TaskSeq<'T> -> Task<bool>
 
     /// <summary>
     /// Tests if any element of the task sequence in <paramref name="source" /> satisfies the given <paramref name="predicate" />. The function
@@ -952,7 +952,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns><see cref="True" /> if any result from the predicate is true; <see cref="false" /> otherwise.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member exists: predicate: ('T -> bool) -> source: taskSeq<'T> -> Task<bool>
+    static member exists: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<bool>
 
     /// <summary>
     /// Tests if any element of the task sequence in <paramref name="source" /> satisfies the given asynchronous <paramref name="predicate" />.
@@ -965,7 +965,7 @@ type TaskSeq =
     /// <param name="source">The input task sequence.</param>
     /// <returns><see cref="True" /> if any result from the predicate is true; <see cref="false" /> otherwise.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member existsAsync: predicate: ('T -> #Task<bool>) -> source: taskSeq<'T> -> Task<bool>
+    static member existsAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<bool>
 
     /// <summary>
     /// Returns a new task sequence with the distinct elements of the second task sequence which do not appear in the
@@ -984,7 +984,7 @@ type TaskSeq =
     /// <returns>A sequence that contains the set difference of the elements of two sequences.</returns>
     ///
     /// <exception cref="T:ArgumentNullException">Thrown when either of the two input task sequences is null.</exception>
-    static member except<'T when 'T: equality> : itemsToExclude: taskSeq<'T> -> source: taskSeq<'T> -> taskSeq<'T>
+    static member except<'T when 'T: equality> : itemsToExclude: TaskSeq<'T> -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Returns a new task sequence with the distinct elements of the second task sequence which do not appear in the
@@ -1003,7 +1003,7 @@ type TaskSeq =
     /// <returns>A sequence that contains the set difference of the elements of two sequences.</returns>
     ///
     /// <exception cref="T:ArgumentNullException">Thrown when either of the two input task sequences is null.</exception>
-    static member exceptOfSeq<'T when 'T: equality> : itemsToExclude: seq<'T> -> source: taskSeq<'T> -> taskSeq<'T>
+    static member exceptOfSeq<'T when 'T: equality> : itemsToExclude: seq<'T> -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Combines the two task sequences into a new task sequence of pairs. The two sequences need not have equal lengths:
@@ -1013,7 +1013,7 @@ type TaskSeq =
     /// <param name="source1">The first input task sequence.</param>
     /// <param name="source2">The second input task sequence.</param>
     /// <exception cref="T:ArgumentNullException">Thrown when either of the two input task sequences is null.</exception>
-    static member zip: source1: taskSeq<'T> -> source2: taskSeq<'U> -> taskSeq<'T * 'U>
+    static member zip: source1: TaskSeq<'T> -> source2: TaskSeq<'U> -> TaskSeq<'T * 'U>
 
     /// <summary>
     /// Applies the function <paramref name="folder" /> to each element in the task sequence, threading an accumulator
@@ -1027,7 +1027,7 @@ type TaskSeq =
     /// <param name="source">The input sequence.</param>
     /// <returns>The state object after the folding function is applied to each element of the sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
-    static member fold: folder: ('State -> 'T -> 'State) -> state: 'State -> source: taskSeq<'T> -> Task<'State>
+    static member fold: folder: ('State -> 'T -> 'State) -> state: 'State -> source: TaskSeq<'T> -> Task<'State>
 
     /// <summary>
     /// Applies the asynchronous function <paramref name="folder" /> to each element in the task sequence, threading an accumulator
@@ -1042,4 +1042,4 @@ type TaskSeq =
     /// <returns>The state object after the folding function is applied to each element of the sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     static member foldAsync:
-        folder: ('State -> 'T -> #Task<'State>) -> state: 'State -> source: taskSeq<'T> -> Task<'State>
+        folder: ('State -> 'T -> #Task<'State>) -> state: 'State -> source: TaskSeq<'T> -> Task<'State>

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -41,7 +41,10 @@ module Internal = // cannot be marked with 'internal' scope
         NotImplementedException "Abstract Class: method or property not implemented"
         |> raise
 
+[<Obsolete "From version 0.4.0 onward, 'taskSeq<'T>' is deprecated in favor of 'TaskSeq<'T>'. It will be removed in an upcoming release.">]
 type taskSeq<'T> = IAsyncEnumerable<'T>
+
+type TaskSeq<'T> = IAsyncEnumerable<'T>
 
 
 [<NoComparison; NoEquality>]

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -41,9 +41,10 @@ module Internal = // cannot be marked with 'internal' scope
         NotImplementedException "Abstract Class: method or property not implemented"
         |> raise
 
-[<Obsolete "From version 0.4.0 onward, 'taskSeq<'T>' is deprecated in favor of 'TaskSeq<'T>'. It will be removed in an upcoming release.">]
+// deprecated from 0.4.0, see FSI file
 type taskSeq<'T> = IAsyncEnumerable<'T>
 
+// the proper type from 0.4.0 onwards, see FSI file
 type TaskSeq<'T> = IAsyncEnumerable<'T>
 
 

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
@@ -25,9 +25,17 @@ module Internal =
     val inline raiseNotImpl: unit -> 'a
 
 /// <summary>
-/// Result of any <see cref="taskSeq" /> computation expression, alias for <see cref="T:System.IAsyncEnumerable&lt;'T&gt;" />.
+/// The type <paramref name="taskSeq&lt;_>" /> is deprecated since version 0.4.0,
+/// please use <paramref name="TaskSeq&lt;_>" /> in its stead. See <see cref="T:FSharp.Control.TaskSeq&lt;_>" />.
 /// </summary>
+[<Obsolete "From version 0.4.0 onward, 'taskSeq<_>' is deprecated in favor of 'TaskSeq<_>'. It will be removed in an upcoming release.">]
 type taskSeq<'T> = IAsyncEnumerable<'T>
+
+/// <summary>
+/// Represents a <see cref="task sequence" /> and is the output of using the <paramref name="taskSeq{...}" />
+/// computation expression from this library. It is an alias for <see cref="T:System.IAsyncEnumerable&lt;_>" />.
+/// </summary>
+type TaskSeq<'T> = IAsyncEnumerable<'T>
 
 /// TaskSeqCode type alias of ResumableCode delegate type, specially recognized by the F# compiler
 and ResumableTSC<'T> = ResumableCode<TaskSeqStateMachineData<'T>, unit>

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
@@ -28,7 +28,7 @@ module Internal =
 /// The type <paramref name="taskSeq&lt;_>" /> is deprecated since version 0.4.0,
 /// please use <paramref name="TaskSeq&lt;_>" /> in its stead. See <see cref="T:FSharp.Control.TaskSeq&lt;_>" />.
 /// </summary>
-[<Obsolete "From version 0.4.0 onward, 'taskSeq<_>' is deprecated in favor of 'TaskSeq<_>'. It will be removed in an upcoming release.">]
+[<Obsolete "From version 0.4.0 onward, 'TaskSeq<_>' is deprecated in favor of 'TaskSeq<_>'. It will be removed in an upcoming release.">]
 type taskSeq<'T> = IAsyncEnumerable<'T>
 
 /// <summary>
@@ -138,7 +138,7 @@ type TaskSeqBuilder =
 
     member inline Combine: task1: ResumableTSC<'T> * task2: ResumableTSC<'T> -> ResumableTSC<'T>
     member inline Delay: f: (unit -> ResumableTSC<'T>) -> ResumableTSC<'T>
-    member inline Run: code: ResumableTSC<'T> -> taskSeq<'T>
+    member inline Run: code: ResumableTSC<'T> -> TaskSeq<'T>
     member inline TryFinally: body: ResumableTSC<'T> * compensationAction: (unit -> unit) -> ResumableTSC<'T>
     member inline TryFinallyAsync: body: ResumableTSC<'T> * compensationAction: (unit -> Task) -> ResumableTSC<'T>
     member inline TryWith: body: ResumableTSC<'T> * catch: (exn -> ResumableTSC<'T>) -> ResumableTSC<'T>
@@ -192,8 +192,8 @@ module MediumPriority =
 
         member inline For: sequence: seq<'TElement> * body: ('TElement -> ResumableTSC<'T>) -> ResumableTSC<'T>
         member inline YieldFrom: source: seq<'T> -> ResumableTSC<'T>
-        member inline For: source: #taskSeq<'TElement> * body: ('TElement -> ResumableTSC<'T>) -> ResumableTSC<'T>
-        member inline YieldFrom: source: taskSeq<'T> -> ResumableTSC<'T>
+        member inline For: source: #TaskSeq<'TElement> * body: ('TElement -> ResumableTSC<'T>) -> ResumableTSC<'T>
+        member inline YieldFrom: source: TaskSeq<'T> -> ResumableTSC<'T>
 
 /// <summary>
 /// Contains low priority extension methods for the main builder class for the <see cref="taskSeq" /> computation expression.

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -67,7 +67,7 @@ module internal TaskSeqInternal =
         KeyNotFoundException("The predicate function or index did not satisfy any item in the async sequence.")
         |> raise
 
-    let isEmpty (source: taskSeq<_>) =
+    let isEmpty (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -102,7 +102,7 @@ module internal TaskSeqInternal =
         }
 
     /// Returns length unconditionally, or based on a predicate
-    let lengthBy predicate (source: taskSeq<_>) =
+    let lengthBy predicate (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -141,7 +141,7 @@ module internal TaskSeqInternal =
         }
 
     /// Returns length unconditionally, or based on a predicate
-    let lengthBeforeMax max (source: taskSeq<_>) =
+    let lengthBeforeMax max (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -160,7 +160,7 @@ module internal TaskSeqInternal =
             return i
         }
 
-    let tryExactlyOne (source: taskSeq<_>) =
+    let tryExactlyOne (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -219,7 +219,7 @@ module internal TaskSeqInternal =
 
     }
 
-    let iter action (source: taskSeq<_>) =
+    let iter action (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -263,7 +263,7 @@ module internal TaskSeqInternal =
                     go <- step
         }
 
-    let fold folder initial (source: taskSeq<_>) =
+    let fold folder initial (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -301,7 +301,7 @@ module internal TaskSeqInternal =
 
     let toResizeArrayAndMapAsync mapper source = (toResizeArrayAsync >> Task.map mapper) source
 
-    let map mapper (source: taskSeq<_>) =
+    let map mapper (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         match mapper with
@@ -333,7 +333,7 @@ module internal TaskSeqInternal =
                 yield result
           }
 
-    let zip (source1: taskSeq<_>) (source2: taskSeq<_>) =
+    let zip (source1: TaskSeq<_>) (source2: TaskSeq<_>) =
         checkNonNull (nameof source1) source1
         checkNonNull (nameof source2) source2
 
@@ -352,7 +352,7 @@ module internal TaskSeqInternal =
                 go <- step1 && step2
         }
 
-    let collect (binder: _ -> #IAsyncEnumerable<_>) (source: taskSeq<_>) =
+    let collect (binder: _ -> #IAsyncEnumerable<_>) (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -360,7 +360,7 @@ module internal TaskSeqInternal =
                 yield! binder c :> IAsyncEnumerable<_>
         }
 
-    let collectSeq (binder: _ -> #seq<_>) (source: taskSeq<_>) =
+    let collectSeq (binder: _ -> #seq<_>) (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -368,7 +368,7 @@ module internal TaskSeqInternal =
                 yield! binder c :> seq<_>
         }
 
-    let collectAsync (binder: _ -> #Task<#IAsyncEnumerable<_>>) (source: taskSeq<_>) =
+    let collectAsync (binder: _ -> #Task<#IAsyncEnumerable<_>>) (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -377,7 +377,7 @@ module internal TaskSeqInternal =
                 yield! result :> IAsyncEnumerable<_>
         }
 
-    let collectSeqAsync (binder: _ -> #Task<#seq<_>>) (source: taskSeq<_>) =
+    let collectSeqAsync (binder: _ -> #Task<#seq<_>>) (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -386,7 +386,7 @@ module internal TaskSeqInternal =
                 yield! result :> seq<_>
         }
 
-    let tryLast (source: taskSeq<_>) =
+    let tryLast (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -406,7 +406,7 @@ module internal TaskSeqInternal =
             | ValueNone -> return None
         }
 
-    let tryHead (source: taskSeq<_>) =
+    let tryHead (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -417,7 +417,7 @@ module internal TaskSeqInternal =
             | false -> return None
         }
 
-    let tryTail (source: taskSeq<_>) =
+    let tryTail (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -440,7 +440,7 @@ module internal TaskSeqInternal =
                     |> Some
         }
 
-    let tryItem index (source: taskSeq<_>) =
+    let tryItem index (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -468,7 +468,7 @@ module internal TaskSeqInternal =
                 return foundItem
         }
 
-    let tryPick chooser (source: taskSeq<_>) =
+    let tryPick chooser (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -503,7 +503,7 @@ module internal TaskSeqInternal =
             return foundItem
         }
 
-    let tryFind predicate (source: taskSeq<_>) =
+    let tryFind predicate (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -542,7 +542,7 @@ module internal TaskSeqInternal =
             return foundItem
         }
 
-    let tryFindIndex predicate (source: taskSeq<_>) =
+    let tryFindIndex predicate (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         task {
@@ -577,7 +577,7 @@ module internal TaskSeqInternal =
             if isFound then return Some index else return None
         }
 
-    let choose chooser (source: taskSeq<_>) =
+    let choose chooser (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -596,7 +596,7 @@ module internal TaskSeqInternal =
                     | None -> ()
         }
 
-    let filter predicate (source: taskSeq<_>) =
+    let filter predicate (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -613,7 +613,7 @@ module internal TaskSeqInternal =
                     | false -> ()
         }
 
-    let takeWhile whileKind predicate (source: taskSeq<_>) =
+    let takeWhile whileKind predicate (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
         taskSeq {
@@ -691,7 +691,7 @@ module internal TaskSeqInternal =
             finally
                 _rwLock.ExitWriteLock()
 
-        member _.AddManyAsync(source: taskSeq<'T>) = task {
+        member _.AddManyAsync(source: TaskSeq<'T>) = task {
             use e = source.GetAsyncEnumerator(ct)
             let mutable go = true
             let! step = e.MoveNextAsync()
@@ -720,7 +720,7 @@ module internal TaskSeqInternal =
 
                 ValueTask.CompletedTask
 
-    let except itemsToExclude (source: taskSeq<_>) =
+    let except itemsToExclude (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
         checkNonNull (nameof itemsToExclude) itemsToExclude
 
@@ -748,7 +748,7 @@ module internal TaskSeqInternal =
 
         }
 
-    let exceptOfSeq itemsToExclude (source: taskSeq<_>) =
+    let exceptOfSeq itemsToExclude (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
         checkNonNull (nameof itemsToExclude) itemsToExclude
 


### PR DESCRIPTION
~**Reviewers note: there are some more changes needed here, like replacing all uses of `TaskSeq<_>`, but I am doing that after #186 is merged**~ DONE.

Similar to have the `Async<_>` and `AsyncSeq<_>` type aliases work, we should follow suit:

* When people use the camelCased version, it will always refer to the computation expression: `taskSeq { do! ... }`
* When they use the PascalCased version, it will always refer to the asynchronous enumerable type `IAsyncEnumerable<_>`, in other words, the output of the computation expression and the building block for basically all functions in this library.

The gist of this change is just that this:

```f#
type taskSeq<'T> = IAsyncEnumerable<'T>
```

becomes

```f#
type TaskSeq<'T> = IAsyncEnumerable<'T>
```


This follows from suggestions made in other issues, but I can't find it readily.

Note that we will keep the lowercase version for some time to come, but with a deprecation warning attached to it.