### PR TITLE
Fix issue #135 use `StartImmediateAsTask` instead of `StartAsTask` to prevent a thread hop

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,9 +1,10 @@
 
 Release notes:
 0.4.x (unreleased)
-    - overhaul all doc comments, add exceptions info, improve tooltips experience, #136
-    - DEPRECATED: type 'TaskSeq<'T>' now replaces 'taskSeq<'T>', the latter deprecated FS0044, #187
-    - BINARY INCOMPATIBLE: TaskSeq module members are now static members, source code compatible, #186
+    - overhaul all doc comments, add exceptions, improve editor experience, #136
+    - DEPRECATED: 'taskSeq<_>' renamed to 'TaskSeq<_>', 'taskSeq' warns with FS0044, #187
+    - BINARY INCOMPATIBILITY: 'TaskSeq' module is now static members on 'TaskSeq<_>', fixes #184
+    - Performance: less thread hops with 'StartImmediateAsTask' instead of 'StartAsTask', fixes #135
 	
 0.4.0-alpha.1
     - fixes not calling Dispose for 'use!', 'use', or `finally` blocks #157 (by @bartelink)

--- a/src/FSharp.Control.TaskSeq/AsyncExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/AsyncExtensions.fs
@@ -8,5 +8,5 @@ module AsyncExtensions =
 
         member _.For(source: TaskSeq<'T>, action: 'T -> Async<unit>) =
             source
-            |> TaskSeq.iterAsync (action >> Async.StartAsTask)
+            |> TaskSeq.iterAsync (action >> Async.StartImmediateAsTask)
             |> Async.AwaitTask

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -648,7 +648,7 @@ module HighPriority =
             ResumableTSC<'U>(fun sm ->
                 let mutable awaiter =
                     Async
-                        .StartAsTask(computation, cancellationToken = sm.Data.cancellationToken)
+                        .StartImmediateAsTask(computation, cancellationToken = sm.Data.cancellationToken)
                         .GetAwaiter()
 
                 let mutable __stack_fin = true


### PR DESCRIPTION
Fixes #135 

This brings our `task`-like behavior in line with the similar change in F# itself, see https://github.com/dotnet/fsharp/pull/14499 (and https://github.com/dotnet/fsharp/pull/14490.

We should probably have a look at these tests (https://github.com/dotnet/fsharp/commit/4054701c43f19e233458dd4c727aa9e212dd854e) and add some of these here as well to ensure we are properly propagating exceptions etc.