### PR TITLE
Ensure local deprecation warnings

### DIFF
--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -42,6 +42,7 @@ module Internal = // cannot be marked with 'internal' scope
         |> raise
 
 // deprecated from 0.4.0, see FSI file
+[<Obsolete "From version 0.4.0 onward, 'TaskSeq<_>' is deprecated in favor of 'TaskSeq<_>'. It will be removed in an upcoming release.">]
 type taskSeq<'T> = IAsyncEnumerable<'T>
 
 // the proper type from 0.4.0 onwards, see FSI file

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fsi
@@ -25,6 +25,8 @@ module Internal =
     val inline raiseNotImpl: unit -> 'a
 
 /// <summary>
+/// Represents a <see cref="task sequence" /> and is the output of using the <paramref name="taskSeq{...}" />
+/// computation expression from this library. It is an alias for <see cref="T:System.IAsyncEnumerable&lt;_>" />.
 /// The type <paramref name="taskSeq&lt;_>" /> is deprecated since version 0.4.0,
 /// please use <paramref name="TaskSeq&lt;_>" /> in its stead. See <see cref="T:FSharp.Control.TaskSeq&lt;_>" />.
 /// </summary>


### PR DESCRIPTION
Tiny PR to ensure we get a local warning when we use the `taskSeq<_>` in our own code.