### PR TITLE
Update fantomas in `src` as well... yep, it is weird

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.2.0",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.0.6",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]


### PR DESCRIPTION
Fantomas needs to be present in two directories. Uhum. Yep, that's how it is. Otherwise, in Visual Studio, it won't work properly with the Format F# plugin.

They also should both have the same version, which is fixed here.