### PR TITLE
Implement `TaskSeq.skipWhile`, `skipWhileAsync`, `skipWhileInclusive` and `skipWhileInclusiveAsync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ This is what has been implemented so far, is planned or skipped:
 | &#x2705; [#90][] | `singleton`        | `singleton`          |                           | |
 | &#x2705; [#209][]| `skip`             | `skip`               |                           | |
 | &#x2705; [#209][]|                    | `drop`               |                           | |
-|                  | `skipWhile`        | `skipWhile`          | `skipWhileAsync`          | |
-|                  |                    | `skipWhileInclusive` | `skipWhileInclusiveAsync` | |
+| &#x2705; [#219][]| `skipWhile`        | `skipWhile`          | `skipWhileAsync`          | |
+| &#x2705; [#219][]|                    | `skipWhileInclusive` | `skipWhileInclusiveAsync` | |
 | &#x2753;         | `sort`             |                      |                           | [note #1](#note1 "These functions require a form of pre-materializing through 'TaskSeq.cache', similar to the approach taken in the corresponding 'Seq' functions. It doesn't make much sense to have a cached async sequence. However, 'AsyncSeq' does implement these, so we'll probably do so eventually as well.") |
 | &#x2753;         | `sortBy`           |                      |                           | [note #1](#note1 "These functions require a form of pre-materializing through 'TaskSeq.cache', similar to the approach taken in the corresponding 'Seq' functions. It doesn't make much sense to have a cached async sequence. However, 'AsyncSeq' does implement these, so we'll probably do so eventually as well.") |
 | &#x2753;         | `sortByAscending`  |                      |                           | [note #1](#note1 "These functions require a form of pre-materializing through 'TaskSeq.cache', similar to the approach taken in the corresponding 'Seq' functions. It doesn't make much sense to have a cached async sequence. However, 'AsyncSeq' does implement these, so we'll probably do so eventually as well.") |
@@ -603,6 +603,7 @@ module TaskSeq =
 [#133]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/133
 [#209]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/209
 [#217]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/217
+[#219]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/219
 
 [issues]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues
 [nuget]: https://www.nuget.org/packages/FSharp.Control.TaskSeq/

--- a/assets/nuget-package-readme.md
+++ b/assets/nuget-package-readme.md
@@ -199,8 +199,8 @@ This is what has been implemented so far, is planned or skipped:
 | &#x2705; [#90][] | `singleton`        | `singleton`          |                           | |
 | &#x2705; [#209][]| `skip`             | `skip`               |                           | |
 | &#x2705; [#209][]|                    | `drop`               |                           | |
-|                  | `skipWhile`        | `skipWhile`          | `skipWhileAsync`          | |
-|                  |                    | `skipWhileInclusive` | `skipWhileInclusiveAsync` | |
+| &#x2705; [#219][]| `skipWhile`        | `skipWhile`          | `skipWhileAsync`          | |
+| &#x2705; [#219][]|                    | `skipWhileInclusive` | `skipWhileInclusiveAsync` | |
 | &#x2753;         | `sort`             |                      |                           | [note #1](#note1 "These functions require a form of pre-materializing through 'TaskSeq.cache', similar to the approach taken in the corresponding 'Seq' functions. It doesn't make much sense to have a cached async sequence. However, 'AsyncSeq' does implement these, so we'll probably do so eventually as well.") |
 | &#x2753;         | `sortBy`           |                      |                           | [note #1](#note1 "These functions require a form of pre-materializing through 'TaskSeq.cache', similar to the approach taken in the corresponding 'Seq' functions. It doesn't make much sense to have a cached async sequence. However, 'AsyncSeq' does implement these, so we'll probably do so eventually as well.") |
 | &#x2753;         | `sortByAscending`  |                      |                           | [note #1](#note1 "These functions require a form of pre-materializing through 'TaskSeq.cache', similar to the approach taken in the corresponding 'Seq' functions. It doesn't make much sense to have a cached async sequence. However, 'AsyncSeq' does implement these, so we'll probably do so eventually as well.") |
@@ -308,3 +308,4 @@ _The motivation for `readOnly` in `Seq` is that a cast from a mutable array or l
 [#126]: https://github.com/fsprojects/FSharp.Control.TaskSeq/pull/126
 [#209]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/209
 [#217]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/217
+[#219]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/219

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -3,9 +3,10 @@ Release notes:
 0.4.x (unreleased)
     - overhaul all doc comments, add exceptions, improve IDE quick-info experience, #136
     - new surface area functions, fixes #208:
-      * TaskSeq.take, TaskSeq.skip, #209
-      * TaskSeq.truncate, TaskSeq.drop, #209
-      * TaskSeq.where, TaskSeq.whereAsync, #217
+      * TaskSeq.take, skip, #209
+      * TaskSeq.truncate, drop, #209
+      * TaskSeq.where, whereAsync, #217
+      * TaskSeq.skipWhile, skipWhileInclusive, skipWhileAsync, skipWhileInclusiveAsync, #219
 
     - Performance: less thread hops with 'StartImmediateAsTask' instead of 'StartAsTask', fixes #135
     - BINARY INCOMPATIBILITY: 'TaskSeq' module is now static members on 'TaskSeq<_>', fixes #184

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="TaskSeq.Pick.Tests.fs" />
     <Compile Include="TaskSeq.Singleton.Tests.fs" />
     <Compile Include="TaskSeq.Skip.Tests.fs" />
+    <Compile Include="TaskSeq.SkipWhile.Tests.fs" />
     <Compile Include="TaskSeq.Tail.Tests.fs" />
     <Compile Include="TaskSeq.Take.Tests.fs" />
     <Compile Include="TaskSeq.TakeWhile.Tests.fs" />

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.SkipWhile.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.SkipWhile.Tests.fs
@@ -72,7 +72,7 @@ module Immutable =
 
         do!
             Gen.getSeqImmutable variant
-            |> TaskSeq.skipWhile ((>) 5) // skip while less than 5
+            |> TaskSeq.skipWhile (fun x -> x < 5)
             |> verifyDigitsAsString "EFGHIJ"
 
         do!
@@ -104,7 +104,7 @@ module Immutable =
 
         do!
             Gen.getSeqImmutable variant
-            |> TaskSeq.skipWhileInclusive ((>) 5)
+            |> TaskSeq.skipWhileInclusive (fun x -> x < 5)
             |> verifyDigitsAsString "FGHIJ" // last 4
 
         do!
@@ -118,12 +118,12 @@ module Immutable =
     let ``TaskSeq-skipWhileInclusive+A returns the empty sequence if always true`` variant = task {
         do!
             Gen.getSeqImmutable variant
-            |> TaskSeq.skipWhileInclusive ((<) -1)
+            |> TaskSeq.skipWhileInclusive (fun x -> x > -1) // always true
             |> verifyEmpty
 
         do!
             Gen.getSeqImmutable variant
-            |> TaskSeq.skipWhileInclusiveAsync (fun x -> task { return true })
+            |> TaskSeq.skipWhileInclusiveAsync (fun x -> Task.fromResult (x > -1))
             |> verifyEmpty
     }
 
@@ -151,7 +151,7 @@ module SideEffects =
 
         do!
             Gen.getSeqWithSideEffect variant
-            |> TaskSeq.skipWhile ((>) 6)
+            |> TaskSeq.skipWhile (fun x -> x < 6)
             |> verifyDigitsAsString "FGHIJ"
 
         do!
@@ -170,7 +170,7 @@ module SideEffects =
 
         do!
             Gen.getSeqWithSideEffect variant
-            |> TaskSeq.skipWhileInclusive ((>) 6)
+            |> TaskSeq.skipWhileInclusive (fun x -> x < 6)
             |> verifyDigitsAsString "GHIJ"
 
         do!
@@ -213,7 +213,7 @@ module SideEffects =
     [<InlineData(true, true)>]
     let ``TaskSeq-skipWhileXXX prove side effects are properly executed`` (inclusive, isAsync) = task {
         let mutable x = 41
-        let functionToTest = getFunction inclusive isAsync ((>) 50)
+        let functionToTest = getFunction inclusive isAsync (fun x -> x < 50)
 
         let items = taskSeq {
             x <- x + 1
@@ -326,7 +326,7 @@ module Other =
                 |> consumeTaskSeq
             |> should throwAsyncExact typeof<SideEffectPastEnd>
 
-        do testSkipper (TaskSeq.skipWhile (fun x -> x <= 2))
-        do testSkipper (TaskSeq.skipWhileInclusive (fun x -> x <= 2))
-        do testSkipper (TaskSeq.skipWhileAsync (fun x -> Task.fromResult (x <= 2)))
-        do testSkipper (TaskSeq.skipWhileInclusiveAsync (fun x -> Task.fromResult (x <= 2)))
+        testSkipper (TaskSeq.skipWhile (fun x -> x <= 2))
+        testSkipper (TaskSeq.skipWhileInclusive (fun x -> x <= 2))
+        testSkipper (TaskSeq.skipWhileAsync (fun x -> Task.fromResult (x <= 2)))
+        testSkipper (TaskSeq.skipWhileInclusiveAsync (fun x -> Task.fromResult (x <= 2)))

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.TakeWhile.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.TakeWhile.Tests.fs
@@ -158,7 +158,7 @@ module SideEffects =
     [<InlineData(false, true)>]
     [<InlineData(true, false)>]
     [<InlineData(true, true)>]
-    let ``TaskSeq-takeWhileXXX prove it does not read beyond the failing yield`` (inclusive, isAsync) = task {
+    let ``TaskSeq-takeWhile and variants prove it does not read beyond the failing yield`` (inclusive, isAsync) = task {
         let mutable x = 42 // for this test, the potential mutation should not actually occur
         let functionToTest = getFunction inclusive isAsync ((=) 42)
 
@@ -183,7 +183,7 @@ module SideEffects =
     [<InlineData(false, true)>]
     [<InlineData(true, false)>]
     [<InlineData(true, true)>]
-    let ``TaskSeq-takeWhileXXX prove side effects are executed`` (inclusive, isAsync) = task {
+    let ``TaskSeq-takeWhile and variants prove side effects are executed`` (inclusive, isAsync) = task {
         let mutable x = 41
         let functionToTest = getFunction inclusive isAsync ((>) 50)
 
@@ -254,7 +254,7 @@ module Other =
     [<InlineData(false, true)>]
     [<InlineData(true, false)>]
     [<InlineData(true, true)>]
-    let ``TaskSeq-takeWhileXXX should exclude all items after predicate fails`` (inclusive, isAsync) =
+    let ``TaskSeq-takeWhile and variants excludes all items after predicate fails`` (inclusive, isAsync) =
         let functionToTest = With.getFunction inclusive isAsync
 
         [ 1; 2; 2; 3; 3; 2; 1 ]
@@ -267,7 +267,7 @@ module Other =
     [<InlineData(false, true)>]
     [<InlineData(true, false)>]
     [<InlineData(true, true)>]
-    let ``TaskSeq-takeWhileXXX stops consuming after predicate fails`` (inclusive, isAsync) =
+    let ``TaskSeq-takeWhile and variants stops consuming after predicate fails`` (inclusive, isAsync) =
         let functionToTest = With.getFunction inclusive isAsync
 
         seq {

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -297,6 +297,10 @@ type TaskSeq private () =
     static member takeWhileAsync predicate source = Internal.takeWhile Exclusive (PredicateAsync predicate) source
     static member takeWhileInclusive predicate source = Internal.takeWhile Inclusive (Predicate predicate) source
     static member takeWhileInclusiveAsync predicate source = Internal.takeWhile Inclusive (PredicateAsync predicate) source
+    static member skipWhile predicate source = Internal.skipWhile Exclusive (Predicate predicate) source
+    static member skipWhileAsync predicate source = Internal.skipWhile Exclusive (PredicateAsync predicate) source
+    static member skipWhileInclusive predicate source = Internal.skipWhile Inclusive (Predicate predicate) source
+    static member skipWhileInclusiveAsync predicate source = Internal.skipWhile Inclusive (PredicateAsync predicate) source
 
     static member tryPick chooser source = Internal.tryPick (TryPick chooser) source
     static member tryPickAsync chooser source = Internal.tryPick (TryPickAsync chooser) source

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -830,10 +830,10 @@ type TaskSeq =
     static member takeWhile: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
-    /// Returns a sequence that, when iterated, yields elements of the underlying sequence while the
+    /// Returns a task sequence that, when iterated, yields elements of the underlying sequence while the
     /// given asynchronous function <paramref name="predicate" /> returns <see cref="true" />, and then returns no further elements.
     /// The first element where the predicate returns <see cref="false" /> is not included in the resulting sequence
-    /// (see also <see cref="TaskSeq.takeWhileInclusive" />).
+    /// (see also <see cref="TaskSeq.takeWhileInclusiveAsync" />).
     /// If <paramref name="predicate" /> is synchronous, consider using <see cref="TaskSeq.takeWhile" />.
     /// </summary>
     ///
@@ -844,7 +844,7 @@ type TaskSeq =
     static member takeWhileAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
-    /// Returns a sequence that, when iterated, yields elements of the underlying sequence until the given
+    /// Returns a task sequence that, when iterated, yields elements of the underlying sequence until the given
     /// function <paramref name="predicate" /> returns <see cref="false" />, returns that element
     /// and then returns no further elements (see also <see cref="TaskSeq.takeWhile" />). This function returns
     /// at least one element of a non-empty sequence, or the empty task sequence if the input is empty.
@@ -858,9 +858,9 @@ type TaskSeq =
     static member takeWhileInclusive: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
-    /// Returns a sequence that, when iterated, yields elements of the underlying sequence until the given
+    /// Returns a task sequence that, when iterated, yields elements of the underlying sequence until the given
     /// asynchronous function <paramref name="predicate" /> returns <see cref="false" />, returns that element
-    /// and then returns no further elements (see also <see cref="TaskSeq.takeWhile" />). This function returns
+    /// and then returns no further elements (see also <see cref="TaskSeq.takeWhileAsync" />). This function returns
     /// at least one element of a non-empty sequence, or the empty task sequence if the input is empty.
     /// If <paramref name="predicate" /> is synchronous, consider using <see cref="TaskSeq.takeWhileInclusive" />.
     /// </summary>
@@ -870,6 +870,62 @@ type TaskSeq =
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     static member takeWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
+
+    /// <summary>
+    /// Returns a task sequence that, when iterated, skips elements of the underlying sequence while the
+    /// given function <paramref name="predicate" /> returns <see cref="true" />, and then yields the remaining
+    /// elements. The first element where the predicate returns <see cref="false" /> is returned, which means that this
+    /// function will skip 0 or more elements (see also <see cref="TaskSeq.skipWhileInclusive" />).
+    /// If <paramref name="predicate" /> is asynchronous, consider using <see cref="TaskSeq.skipWhileAsync" />.
+    /// </summary>
+    ///
+    /// <param name="predicate">A function that evaluates to false when no more items should be skipped.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The resulting task sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member skipWhile: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
+
+    /// <summary>
+    /// Returns a task sequence that, when iterated, skips elements of the underlying sequence while the
+    /// given asynchronous function <paramref name="predicate" /> returns <see cref="true" />, and then yields the
+    /// remaining elements. The first element where the predicate returns <see cref="false" /> is returned, which
+    /// means that this function will skip 0 or more elements (see also <see cref="TaskSeq.skipWhileInclusive" />).
+    /// If <paramref name="predicate" /> is synchronous, consider using <see cref="TaskSeq.skipWhile" />.
+    /// </summary>
+    ///
+    /// <param name="predicate">An asynchronous function that evaluates to false when no more items should be skipped.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The resulting task sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member skipWhileAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
+
+    /// <summary>
+    /// Returns a task sequence that, when iterated, skips elements of the underlying sequence until the given
+    /// function <paramref name="predicate" /> returns <see cref="false" />, also skips that element
+    /// and then yields the remaining elements (see also <see cref="TaskSeq.skipWhile" />). This function skips
+    /// at least one element of a non-empty sequence, or returns the empty task sequence if the input is empty.
+    /// If <paramref name="predicate" /> is asynchronous, consider using <see cref="TaskSeq.skipWhileInclusiveAsync" />.
+    /// </summary>`
+    ///
+    /// <param name="predicate">A function that evaluates to false when no more items should be skipped.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The resulting task sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member skipWhileInclusive: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
+
+    /// <summary>
+    /// Returns a task sequence that, when iterated, skips elements of the underlying sequence until the given
+    /// function <paramref name="predicate" /> returns <see cref="false" />, also skips that element
+    /// and then yields the remaining elements (see also <see cref="TaskSeq.skipWhileAsync" />). This function skips
+    /// at least one element of a non-empty sequence, or returns the empty task sequence if the input is empty.
+    /// If <paramref name="predicate" /> is synchronous, consider using <see cref="TaskSeq.skipWhileInclusive" />.
+    /// </summary>
+    ///
+    /// <param name="predicate">An asynchronous function that evaluates to false when no more items should be skipped.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The resulting task sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member skipWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
     /// Applies the given function <paramref name="chooser" /> to successive elements, returning the first result where

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -889,7 +889,7 @@ type TaskSeq =
     /// Returns a task sequence that, when iterated, skips elements of the underlying sequence while the
     /// given asynchronous function <paramref name="predicate" /> returns <see cref="true" />, and then yields the
     /// remaining elements. The first element where the predicate returns <see cref="false" /> is returned, which
-    /// means that this function will skip 0 or more elements (see also <see cref="TaskSeq.skipWhileInclusive" />).
+    /// means that this function will skip 0 or more elements (see also <see cref="TaskSeq.skipWhileInclusiveAsync" />).
     /// If <paramref name="predicate" /> is synchronous, consider using <see cref="TaskSeq.skipWhile" />.
     /// </summary>
     ///

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -818,12 +818,14 @@ module internal TaskSeqInternal =
 
             | Exclusive, PredicateAsync predicate -> // skipWhileAsync
                 let mutable cont = true
+
                 if more then
                     let! ok = predicate e.Current
                     cont <- ok
 
                 while more && cont do
                     let! moveNext = e.MoveNextAsync()
+
                     if moveNext then
                         let! ok = predicate e.Current
                         cont <- ok
@@ -840,12 +842,14 @@ module internal TaskSeqInternal =
 
             | Inclusive, PredicateAsync predicate -> // skipWhileInclusiveAsync
                 let mutable cont = true
+
                 if more then
                     let! ok = predicate e.Current
                     cont <- ok
 
                 while more && cont do
                     let! moveNext = e.MoveNextAsync()
+
                     if moveNext then
                         let! ok = predicate e.Current
                         cont <- ok
@@ -853,7 +857,7 @@ module internal TaskSeqInternal =
                     more <- moveNext
 
                 if more then
-                     // get the rest, this gives 1 or more semantics
+                    // get the rest, this gives 1 or more semantics
                     while! e.MoveNextAsync() do
                         yield e.Current
         }


### PR DESCRIPTION
Fixes #130

Part of the push for implementing low-hanging from as listed in #208. Implements the following signatures:

```f#
static member skipWhile: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
static member skipWhileAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
static member skipWhileInclusive: predicate: ('T -> bool) -> source: TaskSeq<'T> -> TaskSeq<'T>
static member skipWhileInclusiveAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
```

Note that `inclusive` here means that it skips at least one item (i.e., the modifier applies to the action of skipping). This is analogous to how `takeWhileInclusive` etc work.

Some explanation may be warranted for future reference. Here's a truth table of `1..10` and a filter function of `filter x = x < 5` for both `inclusive` and `non-inclusive` skip functions (also applies to `take` functions):

### `skipWhile`

```
// truth table for f(x) = x < 5
// 1 2 3 4 5 6 7 8 9 10
// T T T T F F F F F F (stops at first F)
// x x x x _ _ _ _ _ _ (skips exclusive)

> [1..10] |> TaskSeq.ofList |> TaskSeq.skipWhile (fun x -> x < 5);;
val it: TaskSeq<int> = taskSeq [5; 6; 7; 8; 9; 10]
```

### `skipWhileInclusive`

```
// truth table for f(x) = x < 5
// 1 2 3 4 5 6 7 8 9 10
// T T T T F F F F F F (stops at first F)
// x x x x x _ _ _ _ _ (skips inclusive)

> [1..10] |> TaskSeq.ofList |> TaskSeq.skipWhile (fun x -> x < 5);;
val it: TaskSeq<int> = taskSeq [6; 7; 8; 9; 10]
```