### PR TITLE
Implement `max|min`, `maxBy|minBy` and `maxByAsync|minByAsync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ This is what has been implemented so far, is planned or skipped:
 | &#x1f6ab;        | `mapFoldBack`      |                      |                           | [note #2](#note2 "Because of the async nature of TaskSeq sequences, iterating from the back would be bad practice. Instead, materialize the sequence to a list or array and then apply the 'Back' iterators.") |
 | &#x2705; [#2][]  | `mapi`             | `mapi`               | `mapiAsync`               | |
 |                  | `mapi2`            | `mapi2`              | `mapi2Async`              | |
-|                  | `max`              | `max`                |                           | |
-|                  | `maxBy`            | `maxBy`              | `maxByAsync`              | |
-|                  | `min`              | `min`                |                           | |
-|                  | `minBy`            | `minBy`              | `minByAsync`              | |
+| &#x2705; [#221][]| `max`              | `max`                |                           | |
+| &#x2705; [#221][]| `maxBy`            | `maxBy`              | `maxByAsync`              | |
+| &#x2705; [#221][]| `min`              | `min`                |                           | |
+| &#x2705; [#221][]| `minBy`            | `minBy`              | `minByAsync`              | |
 | &#x2705; [#2][]  | `ofArray`          | `ofArray`            |                           | |
 | &#x2705; [#2][]  |                    | `ofAsyncArray`       |                           | |
 | &#x2705; [#2][]  |                    | `ofAsyncList`        |                           | |
@@ -511,7 +511,12 @@ module TaskSeq =
     val mapAsync: mapper: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
     val mapi: mapper: (int -> 'T -> 'U) -> source: TaskSeq<'T> -> TaskSeq<'U>
     val mapiAsync: mapper: (int -> 'T -> #Task<'U>) -> source: TaskSeq<'T> -> TaskSeq<'U>
-    val ofArray: source: 'T[] -> TaskSeq<'T>
+    val max: source: TaskSeq<'T> -> Task<'T> when 'T: comparison
+    val max: source: TaskSeq<'T> -> Task<'T> when 'T: comparison
+    val maxBy: projection: ('T -> 'U) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+    val minBy: projection: ('T -> 'U) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+    val maxByAsync: projection: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+    val minByAsync: projection: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison    val ofArray: source: 'T[] -> TaskSeq<'T>
     val ofAsyncArray: source: Async<'T> array -> TaskSeq<'T>
     val ofAsyncList: source: Async<'T> list -> TaskSeq<'T>
     val ofAsyncSeq: source: seq<Async<'T>> -> TaskSeq<'T>
@@ -604,6 +609,7 @@ module TaskSeq =
 [#209]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/209
 [#217]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/217
 [#219]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/219
+[#221]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/221
 
 [issues]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues
 [nuget]: https://www.nuget.org/packages/FSharp.Control.TaskSeq/

--- a/assets/nuget-package-readme.md
+++ b/assets/nuget-package-readme.md
@@ -169,10 +169,10 @@ This is what has been implemented so far, is planned or skipped:
 | &#x1f6ab;        | `mapFoldBack`      |                      |                           | [note #2](#note2 "Because of the async nature of TaskSeq sequences, iterating from the back would be bad practice. Instead, materialize the sequence to a list or array and then apply the 'Back' iterators.") |
 | &#x2705; [#2][]  | `mapi`             | `mapi`               | `mapiAsync`               | |
 |                  | `mapi2`            | `mapi2`              | `mapi2Async`              | |
-|                  | `max`              | `max`                |                           | |
-|                  | `maxBy`            | `maxBy`              | `maxByAsync`              | |
-|                  | `min`              | `min`                |                           | |
-|                  | `minBy`            | `minBy`              | `minByAsync`              | |
+| &#x2705; [#221][]| `max`              | `max`                |                           | |
+| &#x2705; [#221][]| `maxBy`            | `maxBy`              | `maxByAsync`              | |
+| &#x2705; [#221][]| `min`              | `min`                |                           | |
+| &#x2705; [#221][]| `minBy`            | `minBy`              | `minByAsync`              | |
 | &#x2705; [#2][]  | `ofArray`          | `ofArray`            |                           | |
 | &#x2705; [#2][]  |                    | `ofAsyncArray`       |                           | |
 | &#x2705; [#2][]  |                    | `ofAsyncList`        |                           | |
@@ -309,3 +309,4 @@ _The motivation for `readOnly` in `Seq` is that a cast from a mutable array or l
 [#209]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/209
 [#217]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/217
 [#219]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/219
+[#221]: https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/221

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -7,6 +7,7 @@ Release notes:
       * TaskSeq.truncate, drop, #209
       * TaskSeq.where, whereAsync, #217
       * TaskSeq.skipWhile, skipWhileInclusive, skipWhileAsync, skipWhileInclusiveAsync, #219
+      * TaskSeq.max, min, maxBy, minBy, maxByAsync, minByAsync, #221
 
     - Performance: less thread hops with 'StartImmediateAsTask' instead of 'StartAsTask', fixes #135
     - BINARY INCOMPATIBILITY: 'TaskSeq' module is now static members on 'TaskSeq<_>', fixes #184

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="TaskSeq.Last.Tests.fs" />
     <Compile Include="TaskSeq.Length.Tests.fs" />
     <Compile Include="TaskSeq.Map.Tests.fs" />
+    <Compile Include="TaskSeq.MaxMin.Tests.fs" />
     <Compile Include="TaskSeq.OfXXX.Tests.fs" />
     <Compile Include="TaskSeq.Pick.Tests.fs" />
     <Compile Include="TaskSeq.Singleton.Tests.fs" />

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.MaxMin.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.MaxMin.Tests.fs
@@ -1,0 +1,317 @@
+module TaskSeq.Tests.MaxMin
+
+open System
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Control
+
+//
+// TaskSeq.max
+// TaskSeq.min
+// TaskSeq.maxBy
+// TaskSeq.minBy
+// TaskSeq.maxByAsync
+// TaskSeq.minByAsync
+//
+
+type MinMax =
+    | Max = 0
+    | Min = 1
+    | MaxBy = 2
+    | MinBy = 3
+    | MaxByAsync = 4
+    | MinByAsync = 5
+
+module MinMax =
+    let getFunction =
+        function
+        | MinMax.Max -> TaskSeq.max
+        | MinMax.Min -> TaskSeq.min
+        | MinMax.MaxBy -> TaskSeq.maxBy id
+        | MinMax.MinBy -> TaskSeq.minBy id
+        | MinMax.MaxByAsync -> TaskSeq.maxByAsync Task.fromResult
+        | MinMax.MinByAsync -> TaskSeq.minByAsync Task.fromResult
+        | _ -> failwith "impossible"
+
+    let getByFunction =
+        function
+        | MinMax.MaxBy -> TaskSeq.maxBy
+        | MinMax.MinBy -> TaskSeq.minBy
+        | MinMax.MaxByAsync -> fun by -> TaskSeq.maxByAsync (by >> Task.fromResult)
+        | MinMax.MinByAsync -> fun by -> TaskSeq.minByAsync (by >> Task.fromResult)
+        | _ -> failwith "impossible"
+
+    let getAll () =
+        [ MinMax.Max; MinMax.Min; MinMax.MaxBy; MinMax.MinBy; MinMax.MaxByAsync; MinMax.MinByAsync ]
+        |> List.map getFunction
+
+    let getAllMin () =
+        [ MinMax.Min; MinMax.MinBy; MinMax.MinByAsync ]
+        |> List.map getFunction
+
+    let getAllMax () =
+        [ MinMax.Max; MinMax.MaxBy; MinMax.MaxByAsync ]
+        |> List.map getFunction
+
+    let isMin =
+        function
+        | MinMax.Min
+        | MinMax.MinBy
+        | MinMax.MinByAsync -> true
+        | _ -> false
+
+    let isMax = isMin >> not
+
+
+type AllMinMaxFunctions() as this =
+    inherit TheoryData<MinMax>()
+
+    do
+        this.Add MinMax.Max
+        this.Add MinMax.Min
+        this.Add MinMax.MaxBy
+        this.Add MinMax.MinBy
+        this.Add MinMax.MaxByAsync
+        this.Add MinMax.MinByAsync
+
+type JustMin() as this =
+    inherit TheoryData<MinMax>()
+
+    do
+        this.Add MinMax.Min
+        this.Add MinMax.MinBy
+        this.Add MinMax.MinByAsync
+
+type JustMax() as this =
+    inherit TheoryData<MinMax>()
+
+    do
+        this.Add MinMax.Max
+        this.Add MinMax.MaxBy
+        this.Add MinMax.MaxByAsync
+
+type JustMinMaxBy() as this =
+    inherit TheoryData<MinMax>()
+
+    do
+        this.Add MinMax.MaxBy
+        this.Add MinMax.MinBy
+        this.Add MinMax.MaxByAsync
+        this.Add MinMax.MinByAsync
+
+module EmptySeq =
+    [<Theory; ClassData(typeof<AllMinMaxFunctions>)>]
+    let ``Null source raises ArgumentNullException`` (minMaxType: MinMax) =
+        let minMax = MinMax.getFunction minMaxType
+
+        assertNullArg <| fun () -> minMax (null: TaskSeq<int>)
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``Empty sequence raises ArgumentException`` variant =
+        let test minMax =
+            let data = Gen.getEmptyVariant variant
+
+            fun () -> minMax data |> Task.ignore
+            |> should throwAsyncExact typeof<ArgumentException>
+
+        for minMax in MinMax.getAll () do
+            test minMax
+
+module Functionality =
+    [<Fact>]
+    let ``TaskSeq-max should return maximum`` () = task {
+        let ts = [ 'A' .. 'Z' ] |> TaskSeq.ofList
+        let! max = TaskSeq.max ts
+        max |> should equal 'Z'
+    }
+
+    [<Fact>]
+    let ``TaskSeq-maxBy should return maximum of input, not the projection`` () = task {
+        let ts = [ 'A' .. 'Z' ] |> TaskSeq.ofList
+        let! max = TaskSeq.maxBy id ts
+        max |> should equal 'Z'
+
+        let ts = [ 1..10 ] |> TaskSeq.ofList
+        let! max = TaskSeq.maxBy (~-) ts
+        max |> should equal 1 // as negated, -1 is highest, should not return projection, but original
+    }
+
+    [<Fact>]
+    let ``TaskSeq-maxByAsync should return maximum of input, not the projection`` () = task {
+        let ts = [ 'A' .. 'Z' ] |> TaskSeq.ofList
+        let! max = TaskSeq.maxByAsync Task.fromResult ts
+        max |> should equal 'Z'
+
+        let ts = [ 1..10 ] |> TaskSeq.ofList
+        let! max = TaskSeq.maxByAsync (fun x -> Task.fromResult -x) ts
+        max |> should equal 1 // as negated, -1 is highest, should not return projection, but original
+    }
+
+    [<Fact>]
+    let ``TaskSeq-min should return minimum`` () = task {
+        let ts = [ 'A' .. 'Z' ] |> TaskSeq.ofList
+        let! min = TaskSeq.min ts
+        min |> should equal 'A'
+    }
+
+    [<Fact>]
+    let ``TaskSeq-minBy should return minimum of input, not the projection`` () = task {
+        let ts = [ 'A' .. 'Z' ] |> TaskSeq.ofList
+        let! min = TaskSeq.minBy id ts
+        min |> should equal 'A'
+
+        let ts = [ 1..10 ] |> TaskSeq.ofList
+        let! min = TaskSeq.minBy (~-) ts
+        min |> should equal 10 // as negated, -10 is lowest, should not return projection, but original
+    }
+
+    [<Fact>]
+    let ``TaskSeq-minByAsync should return minimum of input, not the projection`` () = task {
+        let ts = [ 'A' .. 'Z' ] |> TaskSeq.ofList
+        let! min = TaskSeq.minByAsync Task.fromResult ts
+        min |> should equal 'A'
+
+        let ts = [ 1..10 ] |> TaskSeq.ofList
+        let! min = TaskSeq.minByAsync (fun x -> Task.fromResult -x) ts
+        min |> should equal 10 // as negated, 1 is highest, should not return projection, but original
+    }
+
+
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-max, maxBy, maxByAsync returns maximum`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        for max in MinMax.getAllMax () do
+            let! max = max ts
+            max |> should equal 10
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-min, minBy, minByAsync returns minimum`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        for min in MinMax.getAllMin () do
+            let! min = min ts
+            min |> should equal 1
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-maxBy, maxByAsync returns maximum after projection`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+        let! max = ts |> TaskSeq.maxBy (fun x -> -x)
+        max |> should equal 1 // because -1 maps to item '1'
+    }
+
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-minBy, minByAsync returns minimum after projection`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+        let! min = ts |> TaskSeq.minBy (fun x -> -x)
+        min |> should equal 10 // because -10 maps to item 10
+    }
+
+module SideSeffects =
+    [<Fact>]
+    let ``TaskSeq-max, maxBy, maxByAsync prove we execute after-effects`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield i // 2
+            i <- i + 1
+            yield i // 3
+            yield i + 1 // 4
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.max |> Task.map (should equal 4)
+        do! ts |> TaskSeq.maxBy (~-) |> Task.map (should equal 6) // next iteration & negation "-6" maps to "6"
+
+        do!
+            ts
+            |> TaskSeq.maxByAsync Task.fromResult
+            |> Task.map (should equal 12) // no negation
+
+        i |> should equal 12
+    }
+
+    [<Fact>]
+    let ``TaskSeq-min, minBy, minByAsync prove we execute after-effects test`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 1
+            i <- i + 1
+            yield i // 2
+            i <- i + 1
+            yield i // 3
+            yield i + 1 // 4
+            i <- i + 1 // we should get here
+        }
+
+        do! ts |> TaskSeq.min |> Task.map (should equal 2)
+        do! ts |> TaskSeq.minBy (~-) |> Task.map (should equal 8) // next iteration & negation
+
+        do!
+            ts
+            |> TaskSeq.minByAsync Task.fromResult
+            |> Task.map (should equal 10) // no negation
+
+        i |> should equal 12
+    }
+
+
+    [<Theory; ClassData(typeof<JustMax>)>]
+    let ``TaskSeq-max with sequence that changes length`` (minMax: MinMax) = task {
+        let max = MinMax.getFunction minMax
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 10
+            yield! [ 1..i ]
+        }
+
+        do! max ts |> Task.map (should equal 10)
+        do! max ts |> Task.map (should equal 20) // mutable state dangers!!
+        do! max ts |> Task.map (should equal 30) // id
+    }
+
+    [<Theory; ClassData(typeof<JustMin>)>]
+    let ``TaskSeq-min with sequence that changes length`` (minMax: MinMax) = task {
+        let min = MinMax.getFunction minMax
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 10
+            yield! [ 1..i ]
+        }
+
+        do! min ts |> Task.map (should equal 1)
+        do! min ts |> Task.map (should equal 1) // same min after changing state
+        do! min ts |> Task.map (should equal 1) // id
+    }
+
+    [<Theory; ClassData(typeof<JustMinMaxBy>)>]
+    let ``TaskSeq-minBy, maxBy with sequence that changes length`` (minMax: MinMax) = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            i <- i + 10
+            yield! [ 1..i ]
+        }
+
+        let test minMaxFn v =
+            if MinMax.isMin minMax then
+                // this ensures the "min" version behaves like the "max" version
+                minMaxFn (~-) ts |> Task.map (should equal v)
+            else
+                minMaxFn id ts |> Task.map (should equal v)
+
+        do! test (MinMax.getByFunction minMax) 10
+        do! test (MinMax.getByFunction minMax) 20
+        do! test (MinMax.getByFunction minMax) 30
+    }

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -162,6 +162,12 @@ type TaskSeq private () =
     // Utility functions
     //
 
+    static member max source = Internal.maxMin max source
+    static member min source = Internal.maxMin min source
+    static member maxBy projection source = Internal.maxMinBy (<) projection source // looks like 'less than', is 'greater than'
+    static member minBy projection source = Internal.maxMinBy (>) projection source
+    static member maxByAsync projection source = Internal.maxMinByAsync (<) projection source // looks like 'less than', is 'greater than'
+    static member minByAsync projection source = Internal.maxMinByAsync (>) projection source
     static member length source = Internal.lengthBy None source
     static member lengthOrMax max source = Internal.lengthBeforeMax max source
     static member lengthBy predicate source = Internal.lengthBy (Some(Predicate predicate)) source

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -72,6 +72,82 @@ type TaskSeq =
     static member lengthByAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<int>
 
     /// <summary>
+    /// Returns the greatest of all elements of the sequence, compared via <see cref="Operators.max" />.
+    /// </summary>
+    ///
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The largest element of the sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    /// <exception cref="T:ArgumentException">Thrown when the input task sequence is empty.</exception>
+    static member max: source: TaskSeq<'T> -> Task<'T> when 'T: comparison
+
+    /// <summary>
+    /// Returns the smallest of all elements of the sequence, compared via <see cref="Operators.min" />.
+    /// </summary>
+    ///
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The smallest element of the sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    /// <exception cref="T:ArgumentException">Thrown when the input task sequence is empty.</exception>
+    static member min: source: TaskSeq<'T> -> Task<'T> when 'T: comparison
+
+    /// <summary>
+    /// Returns the greatest of all elements of the task sequence, compared via <see cref="Operators.max" />
+    /// on the result of applying the function <paramref name="projection" /> to each element.
+    ///
+    /// If <paramref name="projection" /> is asynchronous, use <see cref="TaskSeq.maxByAsync" />.
+    /// </summary>
+    ///
+    /// <param name="projection">A function to transform items from the input sequence into comparable keys.</param>
+    /// <param name="source">The input sequence.</param>
+    /// <returns>The largest element of the sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
+    /// <exception cref="T:ArgumentException">Thrown when the input sequence is empty.</exception>
+    static member maxBy: projection: ('T -> 'U) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+
+    /// <summary>
+    /// Returns the smallest of all elements of the task sequence, compared via <see cref="Operators.min" />
+    /// on the result of applying the function <paramref name="projection" /> to each element.
+    ///
+    /// If <paramref name="projection" /> is asynchronous, use <see cref="TaskSeq.minByAsync" />.
+    /// </summary>
+    ///
+    /// <param name="projection">A function to transform items from the input sequence into comparable keys.</param>
+    /// <param name="source">The input sequence.</param>
+    /// <returns>The smallest element of the sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
+    /// <exception cref="T:ArgumentException">Thrown when the input sequence is empty.</exception>
+    static member minBy: projection: ('T -> 'U) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+
+    /// <summary>
+    /// Returns the greatest of all elements of the task sequence, compared via <see cref="Operators.max" />
+    /// on the result of applying the function <paramref name="projection" /> to each element.
+    ///
+    /// If <paramref name="projection" /> is synchronous, use <see cref="TaskSeq.maxBy" />.
+    /// </summary>
+    ///
+    /// <param name="projection">A function to transform items from the input sequence into comparable keys.</param>
+    /// <param name="source">The input sequence.</param>
+    /// <returns>The largest element of the sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
+    /// <exception cref="T:ArgumentException">Thrown when the input sequence is empty.</exception>
+    static member maxByAsync: projection: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+
+    /// <summary>
+    /// Returns the smallest of all elements of the task sequence, compared via <see cref="Operators.min" />
+    /// on the result of applying the function <paramref name="projection" /> to each element.
+    ///
+    /// If <paramref name="projection" /> is synchronous, use <see cref="TaskSeq.minBy" />.
+    /// </summary>
+    ///
+    /// <param name="projection">A function to transform items from the input sequence into comparable keys.</param>
+    /// <param name="source">The input sequence.</param>
+    /// <returns>The smallest element of the sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input sequence is null.</exception>
+    /// <exception cref="T:ArgumentException">Thrown when the input sequence is empty.</exception>
+    static member minByAsync: projection: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
+
+    /// <summary>
     /// Returns a task sequence that is given by the delayed specification of a task sequence.
     /// </summary>
     ///

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -195,6 +195,7 @@ module internal TaskSeqInternal =
             return acc
         }
 
+    // 'compare' is either `<` or `>` (i.e, less-than, greater-than resp.)
     let inline maxMinBy ([<InlineIfLambda>] compare) ([<InlineIfLambda>] projection) (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
@@ -213,14 +214,14 @@ module internal TaskSeqInternal =
                 let value = e.Current
                 let currentProjection = projection value
 
-                if compare currentProjection accProjection then
+                if compare accProjection currentProjection then
                     accProjection <- currentProjection
                     accValue <- value
 
             return accValue
         }
 
-
+    // 'compare' is either `<` or `>` (i.e, less-than, greater-than resp.)
     let inline maxMinByAsync ([<InlineIfLambda>] compare) ([<InlineIfLambda>] projectionAsync) (source: TaskSeq<_>) =
         checkNonNull (nameof source) source
 
@@ -240,7 +241,7 @@ module internal TaskSeqInternal =
                 let value = e.Current
                 let! currentProjection = projectionAsync value
 
-                if compare currentProjection accProjection then
+                if compare accProjection currentProjection then
                     accProjection <- currentProjection
                     accValue <- value
 


### PR DESCRIPTION
Part of the push for good coverage of surface area functions, see #208. This implements `min`, `max`, `minBy`, `maxBy`, `minByAsync` and `maxByAsync`. Each of these behave exactly like their `Seq` counterparts:

* raises on `null` input
* raises if the input is the empty task sequence
* returns the `min` or `max` of the input by using `IComparable` semantics (i.e.: `when 'T: comparison`)

The xml doc blibs have been taken from `seq.fs` and modified a bit for readability and applicability to `TaskSeq`.

The signatures are as follows:

```f#
static member max: source: TaskSeq<'T> -> Task<'T> when 'T: comparison
static member max: source: TaskSeq<'T> -> Task<'T> when 'T: comparison

static member maxBy: projection: ('T -> 'U) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
static member minBy: projection: ('T -> 'U) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison

static member maxByAsync: projection: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
static member minByAsync: projection: ('T -> #Task<'U>) -> source: TaskSeq<'T> -> Task<'T> when 'U: comparison
```

