### PR TITLE
Enable `TreatWarningsAsErrors` across the board

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,7 @@
 <Project>
   <Import Project="Version.props" />
+  <PropertyGroup>
+    <!-- Fail CI warning FS3511: This state machine is not statically compilable.-->
+    <WarningsAsErrors>FS3511</WarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,3 @@
 <Project>
   <Import Project="Version.props" />
-  <PropertyGroup>
-    <!-- Fail CI warning FS3511: This state machine is not statically compilable.-->
-    <WarningsAsErrors>FS3511</WarningsAsErrors>
-  </PropertyGroup>
 </Project>

--- a/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.MaxMin.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.MaxMin.Tests.fs
@@ -296,7 +296,7 @@ module SideSeffects =
     }
 
     [<Theory; ClassData(typeof<JustMinMaxBy>)>]
-    let ``TaskSeq-minBy, maxBy with sequence that changes length`` (minMax: MinMax) = task {
+    let ``TaskSeq-minBy, maxBy with sequence that changes length`` (minMax: MinMax) =
         let mutable i = 0
 
         let ts = taskSeq {
@@ -311,7 +311,8 @@ module SideSeffects =
             else
                 minMaxFn id ts |> Task.map (should equal v)
 
-        do! test (MinMax.getByFunction minMax) 10
-        do! test (MinMax.getByFunction minMax) 20
-        do! test (MinMax.getByFunction minMax) 30
-    }
+        task {
+            do! test (MinMax.getByFunction minMax) 10
+            do! test (MinMax.getByFunction minMax) 20
+            do! test (MinMax.getByFunction minMax) 30
+        }

--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Computation expression 'taskSeq' for processing IAsyncEnumerable sequences and module functions</Title>

--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -27,11 +27,9 @@ Generates optimized IL code through resumable state machines, and comes with a c
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OtherFlags></OtherFlags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OtherFlags></OtherFlags>
     <Tailcalls>True</Tailcalls>
   </PropertyGroup>
 


### PR DESCRIPTION
Fail faster for state machine release build warning e.g. in #221 