### PR TITLE
Prefer `IDisposable` over `IAsyncDisposable` for disposing `ReaderWriterLock`

### DIFF
--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -978,12 +978,10 @@ module internal TaskSeqInternal =
                 go <- step
         }
 
-        interface IAsyncDisposable with
-            override _.DisposeAsync() =
+        interface IDisposable with
+            override _.Dispose() =
                 if not (isNull _rwLock) then
                     _rwLock.Dispose()
-
-                ValueTask.CompletedTask
 
     let except itemsToExclude (source: TaskSeq<_>) =
         checkNonNull (nameof source) source


### PR DESCRIPTION
As in the title. This does not fix any bug, but is just a small improvement. No need to `IAsyncDisposable` for internal stuff when there's clearly no async code involved in the disposing of resources (in this case, `ReaderWriterLock`).