### PR TITLE
Xml Doc comment cleanup reassessed

### DIFF
--- a/src/FSharp.Control.TaskSeq.sln.DotSettings
+++ b/src/FSharp.Control.TaskSeq.sln.DotSettings
@@ -6,4 +6,8 @@
     <s:Boolean x:Key="/Default/UserDictionary/Words/=nestings/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=resumable/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=specialcase/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=infinitum/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=iteri/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=taskseqs/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=typeref/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -903,7 +903,7 @@ type TaskSeq =
     /// <summary>
     /// Returns a task sequence that, when iterated, yields elements of the underlying sequence while the
     /// given function <paramref name="predicate" /> returns <see cref="true" />, and then returns no further elements.
-    /// The first element where the predicate returns <see cref="false" /> is not included in the resulting sequence
+    /// Stops consuming the source and yielding items as soon as the predicate returns <c>false</c>.
     /// (see also <see cref="TaskSeq.takeWhileInclusive" />).
     /// If <paramref name="predicate" /> is asynchronous, use <see cref="TaskSeq.takeWhileAsync" />.
     /// </summary>
@@ -917,7 +917,7 @@ type TaskSeq =
     /// <summary>
     /// Returns a task sequence that, when iterated, yields elements of the underlying sequence while the
     /// given asynchronous function <paramref name="predicate" /> returns <see cref="true" />, and then returns no further elements.
-    /// The first element where the predicate returns <see cref="false" /> is not included in the resulting sequence
+    /// Stops consuming the source and yielding items as soon as the predicate returns <c>false</c>.
     /// (see also <see cref="TaskSeq.takeWhileInclusiveAsync" />).
     /// If <paramref name="predicate" /> is synchronous, use <see cref="TaskSeq.takeWhile" />.
     /// </summary>

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -1246,8 +1246,8 @@ type TaskSeq =
 
     /// <summary>
     /// Applies the function <paramref name="folder" /> to each element in the task sequence, threading an accumulator
-    /// argument of type <typeref name="'State" /> through the computation.  If the input function is <code>f</code> and the elements are <code>i0...iN</code>
-    /// then computes <code>f (... (f s i0)...) iN</code>.
+    /// argument of type <typeref name="'State" /> through the computation.  If the input function is <paramref name="f" /> and the elements are <paramref name="i0...iN" />
+    /// then computes<paramref name="f (... (f s i0)...) iN" />.
     /// If the accumulator function <paramref name="folder" /> is asynchronous, consider using <see cref="TaskSeq.foldAsync" />.
     /// argument of type <paramref name="'State" /> through the computation.  If the input function is <paramref name="f" /> and the elements are <paramref name="i0...iN" />
     /// then computes <paramref name="f (... (f s i0)...) iN" />.


### PR DESCRIPTION
This is based off of #220, but rebased against main, and with squashed and reordered commits.

Some changes had to be reverted, like an `IDisposable` implementation that was changed into an `IAsyncDisposable`  one, which changes behavior, and may not work anymore with "normal" `use` applications (this was a product of rebasing, this change was not present in #220. But we do have to be careful here. Anything that is disposable must ALWAYS implement `IDisposable`. If the action that does the disposing is asynchronous, it may ALSO implement `IAsyncDisposable`, but this is not a requirement.)

Also, occurrences like the use of `<code>...</code>` in xml doc comments summaries needed to be removed (unfortunately). They lead to garbled popup descriptions in VSCode, and in Visual Studio there's no discernible difference at all (TODO: raise as bugs to the respective communities).

For instance, a section like this:

```
    /// <summary>
    /// Returns <see cref="true" /> if the task sequence contains no elements, <see cref="false" /> otherwise.
    /// <code>this is code!</code>.
    /// </summary>
```

is rendered like this:

![image](https://github.com/fsprojects/FSharp.Control.TaskSeq/assets/16015770/79104469-7d20-4ab4-b546-39f069644813)

Hence the use of hacks like `<paramref>`:

```
    /// Returns <see cref="true" /> if the task sequence contains no elements, <see cref="false" /> otherwise.
    /// <paramref name="this is code!" />.
```

this is, of course, not ideal, but it renders as follows, which is an improvement, but we'll need a more permanent fix:
![image](https://github.com/fsprojects/FSharp.Control.TaskSeq/assets/16015770/d2a3f765-20b5-4d22-ab0a-0f3a020fbda8)


For the same reason, `true` and `false`  are surrounded by `<see cref` tags. Note that in Visual Studio, the coloring is slightly better at times, but still not ideal. Trying to find the lowest common denominator is, frankly speaking, a mess.