### PR TITLE
Improve `takewhile`, `takeWhileInclusive` and `skipwhile`, `skipWhileInclusive`

### DIFF
--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -303,10 +303,10 @@ type TaskSeq private () =
     static member takeWhileAsync predicate source = Internal.takeWhile false (PredicateAsync predicate) source
     static member takeWhileInclusive predicate source = Internal.takeWhile true (Predicate predicate) source
     static member takeWhileInclusiveAsync predicate source = Internal.takeWhile true (PredicateAsync predicate) source
-    static member skipWhile predicate source = Internal.skipWhile Exclusive (Predicate predicate) source
-    static member skipWhileAsync predicate source = Internal.skipWhile Exclusive (PredicateAsync predicate) source
-    static member skipWhileInclusive predicate source = Internal.skipWhile Inclusive (Predicate predicate) source
-    static member skipWhileInclusiveAsync predicate source = Internal.skipWhile Inclusive (PredicateAsync predicate) source
+    static member skipWhile predicate source = Internal.skipWhile false (Predicate predicate) source
+    static member skipWhileAsync predicate source = Internal.skipWhile false (PredicateAsync predicate) source
+    static member skipWhileInclusive predicate source = Internal.skipWhile true (Predicate predicate) source
+    static member skipWhileInclusiveAsync predicate source = Internal.skipWhile true (PredicateAsync predicate) source
 
     static member tryPick chooser source = Internal.tryPick (TryPick chooser) source
     static member tryPickAsync chooser source = Internal.tryPick (TryPickAsync chooser) source

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -299,10 +299,10 @@ type TaskSeq private () =
     static member take count source = Internal.skipOrTake Take count source
     static member truncate count source = Internal.skipOrTake Truncate count source
 
-    static member takeWhile predicate source = Internal.takeWhile Exclusive (Predicate predicate) source
-    static member takeWhileAsync predicate source = Internal.takeWhile Exclusive (PredicateAsync predicate) source
-    static member takeWhileInclusive predicate source = Internal.takeWhile Inclusive (Predicate predicate) source
-    static member takeWhileInclusiveAsync predicate source = Internal.takeWhile Inclusive (PredicateAsync predicate) source
+    static member takeWhile predicate source = Internal.takeWhile false (Predicate predicate) source
+    static member takeWhileAsync predicate source = Internal.takeWhile false (PredicateAsync predicate) source
+    static member takeWhileInclusive predicate source = Internal.takeWhile true (Predicate predicate) source
+    static member takeWhileInclusiveAsync predicate source = Internal.takeWhile true (PredicateAsync predicate) source
     static member skipWhile predicate source = Internal.skipWhile Exclusive (Predicate predicate) source
     static member skipWhileAsync predicate source = Internal.skipWhile Exclusive (PredicateAsync predicate) source
     static member skipWhileInclusive predicate source = Internal.skipWhile Inclusive (Predicate predicate) source


### PR DESCRIPTION
Base on input from #223 (thanks @bartelink) and me rethinking my own wrong assumptions (see https://github.com/fsprojects/FSharp.Control.TaskSeq/pull/223#issuecomment-1998830839), we're now finally a step in the right direction: back to simplified and easy-to-read algorithms (imho).

TODO:

- [x] refactor / improve `takeWhile` and `takeWhileInclusive`
- [x] refactor / improve `skipWhile` and `skipWhileInclusive`