### PR TITLE
Cleanup or clarify unnecessary `#nowarn` statements

### DIFF
--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fs
@@ -8,8 +8,8 @@ open Microsoft.FSharp.Core.CompilerServices
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 
 // note: these are *not* experimental features anymore, but they forgot to switch off the flag
-#nowarn "57" // Experimental library feature, requires '--languversion:preview'.
-#nowarn "1204" // This construct is for use by compiled F# code ans should not be used directly.
+#nowarn "57" // Experimental library feature, requires '--langversion:preview'.
+#nowarn "1204" // This construct is for use by compiled F# code and should not be used directly.
 
 [<AutoOpen>]
 module TaskExtensions =
@@ -42,6 +42,8 @@ module TaskExtensions =
 
                         // This will yield with __stack_fin = false
                         // This will resume with __stack_fin = true
+
+                        // NOTE (AB): if this extra let-binding isn't here, we get NRE exceptions, infinite loops (end of seq not signaled) and warning FS3513
                         let __stack_yield_fin = ResumableCode.Yield().Invoke(&sm)
                         __stack_condition_fin <- __stack_yield_fin
 

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fs
@@ -7,9 +7,9 @@ open System.Threading.Tasks
 open Microsoft.FSharp.Core.CompilerServices
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 
-#nowarn "57"
-#nowarn "1204"
-#nowarn "3513"
+// note: these are *not* experimental features anymore, but they forgot to switch off the flag
+#nowarn "57" // Experimental library feature, requires '--languversion:preview'.
+#nowarn "1204" // This construct is for use by compiled F# code ans should not be used directly.
 
 [<AutoOpen>]
 module TaskExtensions =

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
@@ -1,6 +1,6 @@
 namespace FSharp.Control
 
-#nowarn "1204"
+#nowarn "1204" // This construct is for use by compiled F# code ans should not be used directly.
 
 [<AutoOpen>]
 module TaskExtensions =

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
@@ -1,6 +1,6 @@
 namespace FSharp.Control
 
-#nowarn "1204" // This construct is for use by compiled F# code ans should not be used directly.
+#nowarn "1204" // This construct is for use by compiled F# code and should not be used directly.
 
 [<AutoOpen>]
 module TaskExtensions =

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -4,8 +4,6 @@ open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
 
-#nowarn "57"
-
 // Just for convenience
 module Internal = TaskSeqInternal
 

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -3,8 +3,6 @@ namespace FSharp.Control
 open System.Collections.Generic
 open System.Threading.Tasks
 
-#nowarn "1204"
-
 [<AutoOpen>]
 module TaskSeqExtensions =
     module TaskSeq =

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -3,7 +3,7 @@ namespace FSharp.Control
 open System.Diagnostics
 
 // note: this is *not* an experimental feature, but they forgot to switch off the flag
-#nowarn "57" // Experimental library feature, requires '--languversion:preview'.
+#nowarn "57" // Experimental library feature, requires '--langversion:preview'.
 
 open System
 open System.Collections.Generic
@@ -395,7 +395,7 @@ type TaskSeqBuilder() =
 
         ResumableCode.Combine(task1, task2)
 
-    /// Used by `For`. F# currently doesn't support `while!`, so this cannot be called directly from the CE
+    /// Used by `For`. Unclear if the new `while!` (from F# 8.0) hits this
     member inline _.WhileAsync([<InlineIfLambda>] condition: unit -> ValueTask<bool>, body: ResumableTSC<'T>) : ResumableTSC<'T> =
         let mutable condition_res = true
 
@@ -415,8 +415,11 @@ type TaskSeqBuilder() =
 
                     let task = __stack_vtask.AsTask()
                     let mutable awaiter = task.GetAwaiter()
+
                     // This will yield with __stack_fin = false
                     // This will resume with __stack_fin = true
+
+                    // NOTE (AB): if this extra let-binding isn't here, we get NRE exceptions, infinite loops (end of seq not signaled) and warning FS3513
                     let __stack_yield_fin = ResumableCode.Yield().Invoke(&sm)
                     __stack_condition_fin <- __stack_yield_fin
 

--- a/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqBuilder.fs
@@ -2,7 +2,8 @@ namespace FSharp.Control
 
 open System.Diagnostics
 
-#nowarn "57" // note: this is *not* an experimental feature, but they forgot to switch off the flag
+// note: this is *not* an experimental feature, but they forgot to switch off the flag
+#nowarn "57" // Experimental library feature, requires '--languversion:preview'.
 
 open System
 open System.Collections.Generic
@@ -12,7 +13,7 @@ open System.Runtime.CompilerServices
 open System.Threading.Tasks.Sources
 
 open FSharp.Core.CompilerServices
-open FSharp.Core.CompilerServices.StateMachineHelpers
+open FSharp.Core.CompilerServices.StateMachineHelpers // raises warning FS0057
 open FSharp.Control
 
 


### PR DESCRIPTION
Just some housekeeping about `#nowarn`.

Note that `FS0057` is:

> Experimental library feature, requires '--langversion:preview'.

which it really isn't (one is even raised as the result of an `open` statement??)