### PR TITLE
Implement `TaskSeq.forall` and `forallAsync`

### DIFF
--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="TaskSeq.FindIndex.Tests.fs" />
     <Compile Include="TaskSeq.Find.Tests.fs" />
     <Compile Include="TaskSeq.Fold.Tests.fs" />
+    <Compile Include="TaskSeq.Forall.Tests.fs" />
     <Compile Include="TaskSeq.Head.Tests.fs" />
     <Compile Include="TaskSeq.Indexed.Tests.fs" />
     <Compile Include="TaskSeq.Init.Tests.fs" />

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Exists.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Exists.Tests.fs
@@ -82,7 +82,7 @@ module Immutable =
 
 module SideEffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-exists KeyNotFoundException only sometimes for mutated state`` variant = task {
+    let ``TaskSeq-exists success only sometimes for mutated state`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
         let finder = (=) 11
 
@@ -100,7 +100,7 @@ module SideEffects =
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-existsAsync KeyNotFoundException only sometimes for mutated state`` variant = task {
+    let ``TaskSeq-existsAsync success only sometimes for mutated state`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
         let finder x = task { return x = 11 }
 
@@ -201,7 +201,7 @@ module SideEffects =
         found |> should be True
         i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
 
-        // find some next item. We do get a new iterator, but mutable state is now starting at '1'
+        // find some next item. We do get a new iterator, but mutable state is now still starting at '0'
         let! found = ts |> TaskSeq.exists ((=) 4)
         found |> should be True
         i |> should equal 4 // only partial evaluation!
@@ -221,7 +221,7 @@ module SideEffects =
         found |> should be True
         i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
 
-        // find some next item. We do get a new iterator, but mutable state is now starting at '1'
+        // find some next item. We do get a new iterator, but mutable state is now still starting at '0'
         let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 4 })
         found |> should be True
         i |> should equal 4 // only partial evaluation!

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Forall.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Forall.Tests.fs
@@ -1,0 +1,228 @@
+module TaskSeq.Tests.Exists
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Control
+
+//
+// TaskSeq.exists
+// TaskSeq.existsAsyncc
+//
+
+module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.exists (fun _ -> false) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.existsAsync (fun _ -> Task.fromResult false) null
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-exists returns false`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.exists ((=) 12)
+        |> Task.map (should be False)
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-existsAsync returns false`` variant =
+        Gen.getEmptyVariant variant
+        |> TaskSeq.existsAsync (fun x -> task { return x = 12 })
+        |> Task.map (should be False)
+
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exists sad path returns false`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.exists ((=) 0)
+        |> Task.map (should be False)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-existsAsync sad path return false`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.existsAsync (fun x -> task { return x = 0 })
+        |> Task.map (should be False)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exists happy path middle of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.exists (fun x -> x < 6 && x > 4)
+        |> Task.map (should be True)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-existsAsync happy path middle of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.existsAsync (fun x -> task { return x < 6 && x > 4 })
+        |> Task.map (should be True)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exists happy path first item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.exists ((=) 1)
+        |> Task.map (should be True)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-existsAsync happy path first item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.existsAsync (fun x -> task { return x = 1 })
+        |> Task.map (should be True)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-exists happy path last item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.exists ((=) 10)
+        |> Task.map (should be True)
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-existsAsync happy path last item of seq`` variant =
+        Gen.getSeqImmutable variant
+        |> TaskSeq.existsAsync (fun x -> task { return x = 10 })
+        |> Task.map (should be True)
+
+module SideEffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-exists KeyNotFoundException only sometimes for mutated state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let finder = (=) 11
+
+        // first: false
+        let! found = TaskSeq.exists finder ts
+        found |> should be False
+
+        // find again: found now, because of side effects
+        let! found = TaskSeq.exists finder ts
+        found |> should be True
+
+        // find once more: false
+        let! found = TaskSeq.exists finder ts
+        found |> should be False
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-existsAsync KeyNotFoundException only sometimes for mutated state`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+        let finder x = task { return x = 11 }
+
+        // first: false
+        let! found = TaskSeq.existsAsync finder ts
+        found |> should be False
+
+        // find again: found now, because of side effects
+        let! found = TaskSeq.existsAsync finder ts
+        found |> should be True
+
+        // find once more: false
+        let! found = TaskSeq.existsAsync finder ts
+        found |> should be False
+    }
+
+    [<Fact>]
+    let ``TaskSeq-exists _specialcase_ prove we don't read past the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.exists ((=) 3)
+        found |> should be True
+        i |> should equal 3 // only partial evaluation!
+
+        // find next item. We do get a new iterator, but mutable state is now starting at '3', so first item now returned is '4'.
+        let! found = ts |> TaskSeq.exists ((=) 4)
+        found |> should be True
+        i |> should equal 4 // only partial evaluation!
+    }
+
+    [<Fact>]
+    let ``TaskSeq-existsAsync _specialcase_ prove we don't read past the found item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 3 })
+        found |> should be True
+        i |> should equal 3 // only partial evaluation!
+
+        // find next item. We do get a new iterator, but mutable state is now starting at '3', so first item now returned is '4'.
+        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 4 })
+        found |> should be True
+        i |> should equal 4
+    }
+
+    [<Fact>]
+    let ``TaskSeq-exists _specialcase_ prove we don't read past the found item v2`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            yield 42
+            i <- i + 1
+            i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.exists ((=) 42)
+        found |> should be True
+        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-existsAsync _specialcase_ prove we don't read past the found item v2`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            yield 42
+            i <- i + 1
+            i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 42 })
+        found |> should be True
+        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
+    }
+
+    [<Fact>]
+    let ``TaskSeq-exists _specialcase_ prove statement after yield is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.exists ((=) 0)
+        found |> should be True
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+
+        // find some next item. We do get a new iterator, but mutable state is now starting at '1'
+        let! found = ts |> TaskSeq.exists ((=) 4)
+        found |> should be True
+        i |> should equal 4 // only partial evaluation!
+    }
+
+    [<Fact>]
+    let ``TaskSeq-existsAsync _specialcase_ prove statement after yield is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 0 })
+        found |> should be True
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+
+        // find some next item. We do get a new iterator, but mutable state is now starting at '1'
+        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 4 })
+        found |> should be True
+        i |> should equal 4 // only partial evaluation!
+    }

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.Forall.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.Forall.Tests.fs
@@ -1,4 +1,4 @@
-module TaskSeq.Tests.Exists
+module TaskSeq.Tests.Forall
 
 open Xunit
 open FsUnit.Xunit
@@ -6,119 +6,137 @@ open FsUnit.Xunit
 open FSharp.Control
 
 //
-// TaskSeq.exists
-// TaskSeq.existsAsyncc
+// TaskSeq.forall
+// TaskSeq.forallAsyncc
 //
 
 module EmptySeq =
     [<Fact>]
     let ``Null source is invalid`` () =
         assertNullArg
-        <| fun () -> TaskSeq.exists (fun _ -> false) null
+        <| fun () -> TaskSeq.forall (fun _ -> false) null
 
         assertNullArg
-        <| fun () -> TaskSeq.existsAsync (fun _ -> Task.fromResult false) null
+        <| fun () -> TaskSeq.forallAsync (fun _ -> Task.fromResult false) null
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
-    let ``TaskSeq-exists returns false`` variant =
+    let ``TaskSeq-forall always returns true`` variant =
         Gen.getEmptyVariant variant
-        |> TaskSeq.exists ((=) 12)
-        |> Task.map (should be False)
+        |> TaskSeq.forall ((=) 12)
+        |> Task.map (should be True)
 
     [<Theory; ClassData(typeof<TestEmptyVariants>)>]
-    let ``TaskSeq-existsAsync returns false`` variant =
+    let ``TaskSeq-forallAsync always returns true`` variant =
         Gen.getEmptyVariant variant
-        |> TaskSeq.existsAsync (fun x -> task { return x = 12 })
-        |> Task.map (should be False)
+        |> TaskSeq.forallAsync (fun x -> task { return x = 12 })
+        |> Task.map (should be True)
 
 module Immutable =
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-exists sad path returns false`` variant =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.exists ((=) 0)
-        |> Task.map (should be False)
+    let ``TaskSeq-forall sad path returns false`` variant = task {
+        do!
+            Gen.getSeqImmutable variant
+            |> TaskSeq.forall ((=) 0)
+            |> Task.map (should be False)
+
+        do!
+            Gen.getSeqImmutable variant
+            |> TaskSeq.forall ((>) 9) // lt
+            |> Task.map (should be False)
+    }
 
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-existsAsync sad path return false`` variant =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.existsAsync (fun x -> task { return x = 0 })
-        |> Task.map (should be False)
+    let ``TaskSeq-forallAsync sad path returns false`` variant = task {
+        do!
+            Gen.getSeqImmutable variant
+            |> TaskSeq.forallAsync (fun x -> task { return x = 0 })
+            |> Task.map (should be False)
+
+        do!
+            Gen.getSeqImmutable variant
+            |> TaskSeq.forallAsync (fun x -> task { return x < 9 })
+            |> Task.map (should be False)
+    }
 
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-exists happy path middle of seq`` variant =
+    let ``TaskSeq-forall happy path whole seq true`` variant =
         Gen.getSeqImmutable variant
-        |> TaskSeq.exists (fun x -> x < 6 && x > 4)
+        |> TaskSeq.forall (fun x -> x < 6 || x > 5)
         |> Task.map (should be True)
 
     [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-existsAsync happy path middle of seq`` variant =
+    let ``TaskSeq-forallAsync happy path whole seq true`` variant =
         Gen.getSeqImmutable variant
-        |> TaskSeq.existsAsync (fun x -> task { return x < 6 && x > 4 })
-        |> Task.map (should be True)
-
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-exists happy path first item of seq`` variant =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.exists ((=) 1)
-        |> Task.map (should be True)
-
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-existsAsync happy path first item of seq`` variant =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.existsAsync (fun x -> task { return x = 1 })
-        |> Task.map (should be True)
-
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-exists happy path last item of seq`` variant =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.exists ((=) 10)
-        |> Task.map (should be True)
-
-    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
-    let ``TaskSeq-existsAsync happy path last item of seq`` variant =
-        Gen.getSeqImmutable variant
-        |> TaskSeq.existsAsync (fun x -> task { return x = 10 })
+        |> TaskSeq.forallAsync (fun x -> task { return x <= 10 && x >= 0 })
         |> Task.map (should be True)
 
 module SideEffects =
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-exists KeyNotFoundException only sometimes for mutated state`` variant = task {
+    let ``TaskSeq-forall mutated state can change result`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
-        let finder = (=) 11
+        let predicate x = x > 10
 
         // first: false
-        let! found = TaskSeq.exists finder ts
-        found |> should be False
+        let! found = TaskSeq.forall predicate ts
+        found |> should be False // fails on first item, not many side effects yet
+
+        // ensure side effects executes
+        do! consumeTaskSeq ts
 
         // find again: found now, because of side effects
-        let! found = TaskSeq.exists finder ts
+        let! found = TaskSeq.forall predicate ts
         found |> should be True
 
-        // find once more: false
-        let! found = TaskSeq.exists finder ts
-        found |> should be False
+        // find once more, still true, as numbers increase
+        do! consumeTaskSeq ts // ensure side effects executes
+        let! found = TaskSeq.forall predicate ts
+        found |> should be True
     }
 
     [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
-    let ``TaskSeq-existsAsync KeyNotFoundException only sometimes for mutated state`` variant = task {
+    let ``TaskSeq-forallAsync mutated state can change result`` variant = task {
         let ts = Gen.getSeqWithSideEffect variant
-        let finder x = task { return x = 11 }
+        let predicate x = Task.fromResult (x > 10)
 
         // first: false
-        let! found = TaskSeq.existsAsync finder ts
-        found |> should be False
+        let! found = TaskSeq.forallAsync predicate ts
+        found |> should be False // fails on first item, not many side effects yet
+
+        // ensure side effects executes
+        do! consumeTaskSeq ts
 
         // find again: found now, because of side effects
-        let! found = TaskSeq.existsAsync finder ts
+        let! found = TaskSeq.forallAsync predicate ts
         found |> should be True
 
-        // find once more: false
-        let! found = TaskSeq.existsAsync finder ts
+        // find once more, still true, as numbers increase
+        do! consumeTaskSeq ts // ensure side effects executes
+        let! found = TaskSeq.forallAsync predicate ts
+        found |> should be True
+    }
+
+    [<Fact>]
+    let ``TaskSeq-forall _specialcase_ prove we don't read past the first failing item`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                i <- i + 1
+                yield i
+        }
+
+        let! found = ts |> TaskSeq.forall ((>) 3)
         found |> should be False
+        i |> should equal 3 // only partial evaluation!
+
+        // find next item. We do get a new iterator, but mutable state is now starting at '3', so first item now returned is '4'.
+        let! found = ts |> TaskSeq.forall ((<=) 4)
+        found |> should be True
+        i |> should equal 13 // we evaluated to the end
     }
 
     [<Fact>]
-    let ``TaskSeq-exists _specialcase_ prove we don't read past the found item`` () = task {
+    let ``TaskSeq-forallAsync _specialcase_ prove we don't read past the first failing item`` () = task {
         let mutable i = 0
 
         let ts = taskSeq {
@@ -127,68 +145,42 @@ module SideEffects =
                 yield i
         }
 
-        let! found = ts |> TaskSeq.exists ((=) 3)
-        found |> should be True
+        let! found = ts |> TaskSeq.forallAsync (fun x -> Task.fromResult (x < 3))
+        found |> should be False
         i |> should equal 3 // only partial evaluation!
 
         // find next item. We do get a new iterator, but mutable state is now starting at '3', so first item now returned is '4'.
-        let! found = ts |> TaskSeq.exists ((=) 4)
+        let! found =
+            ts
+            |> TaskSeq.forallAsync (fun x -> Task.fromResult (x >= 4))
+
         found |> should be True
+        i |> should equal 13 // we evaluated to the end
+    }
+
+
+    [<Fact>]
+    let ``TaskSeq-forall _specialcase_ prove statement after first false result is not evaluated`` () = task {
+        let mutable i = 0
+
+        let ts = taskSeq {
+            for _ in 0..9 do
+                yield i
+                i <- i + 1
+        }
+
+        let! found = ts |> TaskSeq.forall ((>) 0)
+        found |> should be False
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' was evaluated
+
+        // find some next item. We do get a new iterator, but mutable state is still starting at '0'
+        let! found = ts |> TaskSeq.forall ((>) 4)
+        found |> should be False
         i |> should equal 4 // only partial evaluation!
     }
 
     [<Fact>]
-    let ``TaskSeq-existsAsync _specialcase_ prove we don't read past the found item`` () = task {
-        let mutable i = 0
-
-        let ts = taskSeq {
-            for _ in 0..9 do
-                i <- i + 1
-                yield i
-        }
-
-        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 3 })
-        found |> should be True
-        i |> should equal 3 // only partial evaluation!
-
-        // find next item. We do get a new iterator, but mutable state is now starting at '3', so first item now returned is '4'.
-        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 4 })
-        found |> should be True
-        i |> should equal 4
-    }
-
-    [<Fact>]
-    let ``TaskSeq-exists _specialcase_ prove we don't read past the found item v2`` () = task {
-        let mutable i = 0
-
-        let ts = taskSeq {
-            yield 42
-            i <- i + 1
-            i <- i + 1
-        }
-
-        let! found = ts |> TaskSeq.exists ((=) 42)
-        found |> should be True
-        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
-    }
-
-    [<Fact>]
-    let ``TaskSeq-existsAsync _specialcase_ prove we don't read past the found item v2`` () = task {
-        let mutable i = 0
-
-        let ts = taskSeq {
-            yield 42
-            i <- i + 1
-            i <- i + 1
-        }
-
-        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 42 })
-        found |> should be True
-        i |> should equal 0 // because no MoveNext after found item, the last statements are not executed
-    }
-
-    [<Fact>]
-    let ``TaskSeq-exists _specialcase_ prove statement after yield is not evaluated`` () = task {
+    let ``TaskSeq-forallAsync _specialcase_ prove statement after first false result is not evaluated`` () = task {
         let mutable i = 0
 
         let ts = taskSeq {
@@ -197,32 +189,12 @@ module SideEffects =
                 i <- i + 1
         }
 
-        let! found = ts |> TaskSeq.exists ((=) 0)
-        found |> should be True
-        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
+        let! found = ts |> TaskSeq.forallAsync (fun x -> Task.fromResult (x < 0))
+        found |> should be False
+        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' was evaluated
 
-        // find some next item. We do get a new iterator, but mutable state is now starting at '1'
-        let! found = ts |> TaskSeq.exists ((=) 4)
-        found |> should be True
-        i |> should equal 4 // only partial evaluation!
-    }
-
-    [<Fact>]
-    let ``TaskSeq-existsAsync _specialcase_ prove statement after yield is not evaluated`` () = task {
-        let mutable i = 0
-
-        let ts = taskSeq {
-            for _ in 0..9 do
-                yield i
-                i <- i + 1
-        }
-
-        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 0 })
-        found |> should be True
-        i |> should equal 0 // notice that it should be one higher if the statement after 'yield' is evaluated
-
-        // find some next item. We do get a new iterator, but mutable state is now starting at '1'
-        let! found = ts |> TaskSeq.existsAsync (fun x -> task { return x = 4 })
-        found |> should be True
+        // find some next item. We do get a new iterator, but mutable state is still starting at '0'
+        let! found = ts |> TaskSeq.forallAsync (fun x -> Task.fromResult (x < 4))
+        found |> should be False
         i |> should equal 4 // only partial evaluation!
     }

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -358,6 +358,9 @@ type TaskSeq private () =
     static member except itemsToExclude source = Internal.except itemsToExclude source
     static member exceptOfSeq itemsToExclude source = Internal.exceptOfSeq itemsToExclude source
 
+    static member forall predicate source = Internal.forall (Predicate predicate) source
+    static member forallAsync predicate source = Internal.forall (PredicateAsync predicate) source
+
     static member exists predicate source =
         Internal.tryFind (Predicate predicate) source
         |> Task.map Option.isSome

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -876,6 +876,30 @@ type TaskSeq =
     static member whereAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> TaskSeq<'T>
 
     /// <summary>
+    /// Tests if all elements of the sequence satisfy the given predicate. Stops evaluating
+    /// as soon as <paramref name="predicate" /> returns <see cref="false" />.
+    /// If <paramref name="predicate" /> is asynchronous, consider using <see cref="TaskSeq.forallAsync" />.
+    /// </summary>
+    ///
+    /// <param name="predicate">A function to test an element of the input sequence.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>A task that, after awaiting, holds true if every element of the sequence satisfies the predicate; false otherwise.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member forall: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<bool>
+
+    /// <summary>
+    /// Tests if all elements of the sequence satisfy the given asynchronous predicate. Stops evaluating
+    /// as soon as <paramref name="predicate" /> returns <see cref="false" />.
+    /// If <paramref name="predicate" /> is synchronous, consider using <see cref="TaskSeq.forall" />.
+    /// </summary>
+    ///
+    /// <param name="predicate">A function to test an element of the input sequence.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>A task that, after awaiting, holds true if every element of the sequence satisfies the predicate; false otherwise.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member forallAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<bool>
+
+    /// <summary>
     /// Returns a task sequence that, when iterated, skips <paramref name="count" /> elements of the underlying
     /// sequence, and then yields the remainder. Raises an exception if there are not <paramref name="count" />
     /// items. See <see cref="TaskSeq.drop" /> for a version that does not raise an exception.


### PR DESCRIPTION
Part of the push for good coverage of surface area functions, see #208 for an overview. This implements `TaskSeq.forall`, `TaskSeq.forallAsync`.

Each of these behave exactly like their `Seq` counterparts:

* raises on `null` input

As before, the xml doc blibs have been taken from `seq.fs` and modified a bit for readability and applicability to `TaskSeq`.

The signatures are as follows:

```f#
static member forall: predicate: ('T -> bool) -> source: TaskSeq<'T> -> Task<bool>
static member forallAsync: predicate: ('T -> #Task<bool>) -> source: TaskSeq<'T> -> Task<bool>
```

TODO list:

- [x] implement `TaskSeq.forall`
- [x] Implement `TaskSeq.forallAsync`
- [x] unit tests
