### PR TITLE
Prepare release v0.4.0

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <!-- updating this version will trigger a publish after merge to 'main' -->
-    <Version>0.4.0-alpha.1</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 </Project>

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,38 +1,43 @@
 
 Release notes:
-0.4.x (unreleased)
-    - overhaul all doc comments, add exceptions, improve IDE quick-info experience, #136
+0.4.0
+    - overhaul all doc comments, add exceptions, improve IDE quick-info experience, #136, #220, #234
     - new surface area functions, fixes #208:
       * TaskSeq.take, skip, #209
       * TaskSeq.truncate, drop, #209
       * TaskSeq.where, whereAsync, #217
       * TaskSeq.skipWhile, skipWhileInclusive, skipWhileAsync, skipWhileInclusiveAsync, #219
       * TaskSeq.max, min, maxBy, minBy, maxByAsync, minByAsync, #221
+      * TaskSeq.insertAt, insertManyAt, removeAt, removeManyAt, updateAt, #236
+      * TaskSeq.forall, forallAsync, #240
+      * TaskSeq.concat (overloads: seq, array, resizearray, list), #237
 
     - Performance: less thread hops with 'StartImmediateAsTask' instead of 'StartAsTask', fixes #135
-    - BINARY INCOMPATIBILITY: 'TaskSeq' module is now static members on 'TaskSeq<_>', fixes #184
+    - Performance: several inline and allocation improvements
+    - BINARY INCOMPATIBILITY: 'TaskSeq' module replaced by static members on 'TaskSeq<_>', fixes #184
     - DEPRECATIONS (warning FS0044):
       - type 'taskSeq<_>' is renamed to 'TaskSeq<_>', fixes #193
       - function 'ValueTask.ofIValueTaskSource` renamed to `ValueTask.ofSource`, fixes #193
       - function `ValueTask.FromResult` is renamed to `ValueTask.fromResult`, fixes #193
 
 0.4.0-alpha.1
-    - fixes not calling Dispose for 'use!', 'use', or `finally` blocks #157 (by @bartelink)
+    - bugfix: not calling Dispose for 'use!', 'use', or `finally` blocks #157 (by @bartelink)
     - BREAKING CHANGE: null args now raise ArgumentNullException instead of NullReferenceException, #127
     - adds `let!` and `do!` support for F#'s Async<'T>, #79, #114
     - adds TaskSeq.takeWhile, takeWhileAsync, takeWhileInclusive, takeWhileInclusiveAsync, #126 (by @bartelink)
     - adds AsyncSeq vs TaskSeq comparison chart, #131
-    - removes release-notes.txt from file dependencies, but keep in the package, #138
+    - bugfix: removes release-notes.txt from file dependencies, but keep in the package, #138
 
 0.3.0
-    - internal renames, improved doc comments, signature files for complex types, hide internal-only types, fixes #112.
+    - improved xml doc comments, signature files for exposing types, fixes #112.
     - adds support for static TaskLike, allowing the same let! and do! overloads that F# task supports, fixes #110.
     - implements 'do!' for non-generic Task like with Task.Delay, fixes #43.
-    - adds support for 'for .. in ..' with task sequences in F# tasks and async, #75, #93 and #99 (with help from @theangrybyrd).
+    - task and async CEs extended with support for 'for .. in ..do' with TaskSeq, #75, #93, #99 (in part by @theangrybyrd).
     - adds TaskSeq.singleton, #90 (by @gusty).
-    - fixes overload resolution bug with 'use' and 'use!', #97 (thanks @peterfaria).
+    - bugfix: fixes overload resolution bug with 'use' and 'use!', #97 (thanks @peterfaria).
     - improves TaskSeq.empty by not relying on resumable state, #89 (by @gusty).
-    - does not throw exceptions anymore for unequal lengths in TaskSeq.zip, fixes #32.
+    - bugfix: does not throw exceptions anymore for unequal lengths in TaskSeq.zip, fixes #32.
+    - BACKWARD INCOMPATIBILITY: several internal-only types now hidden
 
 0.2.2
     - removes TaskSeq.toSeqCachedAsync, which was incorrectly named. Use toSeq or toListAsync instead.

--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -13,7 +13,7 @@
 The 'taskSeq' computation expression adds support for awaitable asynchronous sequences with similar ease of use and performance to F#'s 'task' CE, with minimal overhead through ValueTask under the hood. TaskSeq brings 'seq' and 'task' together in a safe way.
 
 Generates optimized IL code through resumable state machines, and comes with a comprehensive set of functions in module 'TaskSeq'. See README for documentation and more info.</Description>
-    <Copyright>Copyright 2023</Copyright>
+    <Copyright>Copyright 2022-2024</Copyright>
     <PackageProjectUrl>https://github.com/fsprojects/FSharp.Control.TaskSeq</PackageProjectUrl>
     <RepositoryUrl>https://github.com/fsprojects/FSharp.Control.TaskSeq</RepositoryUrl>
     <PackageIcon>taskseq-icon.png</PackageIcon>
@@ -22,7 +22,7 @@ Generates optimized IL code through resumable state machines, and comes with a c
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>nuget-package-readme.md</PackageReadmeFile>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../release-notes.txt"))</PackageReleaseNotes>
-    <PackageTags>taskseq;f#;computation expression;IAsyncEnumerable;task;async;asyncseq;</PackageTags>
+    <PackageTags>taskseq;f#;fsharp;asyncseq;seq;sequences;sequential;threading;computation expression;IAsyncEnumerable;task;async;iteration</PackageTags>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
## Major release is there: version 0.4.0 ready to ship!!!

Since version 0.3.0, these are the main changes (from release notes):

## 0.4.0
- overhaul all doc comments, add exceptions, improve IDE quick-info experience,  [#136](136),  [#220](220),  [#234](234) (in coop with @bartelink)
- new surface area functions, fixes [#208](208):
  * `TaskSeq.take`, `skip`, [#209](209)
  * `TaskSeq.truncate`, `drop`, [#209](209)
  * `TaskSeq.where`, `whereAsync`, [#217](217)
  * `TaskSeq.skipWhile`, `skipWhileInclusive`, `skipWhileAsync`, `skipWhileInclusiveAsync`, [#219](219)
  * `TaskSeq.max`, `min`, `maxBy`, `minBy`, `maxByAsync`, `minByAsync`, [#221](221)
  * `TaskSeq.insertAt`, `insertManyAt`, `removeAt`, `removeManyAt`, `updateAt`, [#236](236)
  * `TaskSeq.forall`, `forallAsync`,  [#240](240)
  * `TaskSeq.concat` (overloads: seq, array, resizearray, list),  [#237](237)

- Performance: less thread hops with 'StartImmediateAsTask' instead of 'StartAsTask', fixes  [#135](135)
- Performance: several inline and allocation improvements
- **BINARY INCOMPATIBILITY**: `TaskSeq` module replaced by static members on `TaskSeq<_>`, fixes  [#184](184)
  - applies to all functions in `TaskSeq.xxxx` space
  - any existing code can simply be recompiled
  - replacing the library without recompiling **may** lead to errors
- **DEPRECATIONS** (warning FS0044, old names can still be used):
  - type `taskSeq<_>` is renamed to `TaskSeq<_>`, fixes  [#193](193)
  - function `ValueTask.ofIValueTaskSource` renamed to `ValueTask.ofSource`, fixes [#193](193)
  - function `ValueTask.FromResult` is renamed to `ValueTask.fromResult`, fixes [#193](193)

## 0.4.0-alpha.1
- fixes not calling Dispose for 'use!', 'use', or `finally` blocks [#157](157) (by @bartelink)
- **BREAKING CHANGE**: null args now raise `ArgumentNullException` instead of `NullReferenceException`,  [#127](127)
- adds `let!` and `do!` support for F#'s Async<'T>,  [#79](79),  [#114](114)
- adds `TaskSeq.takeWhile`, `takeWhileAsync`, `takeWhileInclusive`, `takeWhileInclusiveAsync`,  [#126](126) (by @bartelink)
- adds `AsyncSeq` vs `TaskSeq` comparison chart,  [#131](131)
- removes release-notes.txt from file dependencies, but keep in the package,  [#138](138)