### PR TITLE
Fix propagating `%ERRORLEVEL%` in cases where `build.cmd` fails

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,9 @@ jobs:
         uses: actions/setup-dotnet@v4
       # build it, test it, pack it, publish it
       - name: Run dotnet build (release, for nuget)
-        # see issue #105
+        # see issue #105 and #243
         # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
+        shell: cmd
         run: ./build.cmd
       - name: Nuget publish
         # skip-duplicate ensures that the 409 error received when the package was already published,


### PR DESCRIPTION
This was addressed and documented in #105.

However, this change was missed in `publish.yaml`, which means we would never see any errors when `build` is running for a package deploy to nuget,