### PR TITLE
Update dependencies (except FSharp.Core)

### DIFF
--- a/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
@@ -16,8 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- our smoketests use the highest RTM (non-alpha) FSharp.Core, contrary to the base test project, which uses the lowest possible denominator -->
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
+    <!--
+      IMPORTANT: Our smoketests use the highest RTM (non-alpha) FSharp.Core, contrary
+                 to the main test project, which uses the lowest possible denominator (6.0.1)
+                 By NOT including the reference, the F# compiler will automatically choose the
+                 highest version available.
+                 This ensures that, if we have a forwards compat issue, we will get an error.
+    -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
     <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.10.0" />
     <PackageReference Include="FsUnit.xUnit" Version="6.0.0" />

--- a/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
+++ b/src/FSharp.Control.TaskSeq.SmokeTests/FSharp.Control.TaskSeq.SmokeTests.fsproj
@@ -23,16 +23,16 @@
                  highest version available.
                  This ensures that, if we have a forwards compat issue, we will get an error.
     -->
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
-    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.10.0" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
+    <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.15.1" />
     <PackageReference Include="FsUnit.xUnit" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -60,7 +60,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- align test project with minimal required version for TaskSeq, which is 6.0.1 at the moment -->
+    <!--
+      Align test project with minimal required version for TaskSeq, which is 6.0.1 at the moment.
+      This updates the default reference (which is the highest stable version) to be the oldest,
+      still compatible version of the TaskSeq library.
+    -->
     <PackageReference Update="FSharp.Core" Version="6.0.1" />
     <PackageReference Include="FsUnit.xUnit" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -68,12 +68,12 @@
     <PackageReference Update="FSharp.Core" Version="6.0.1" />
     <PackageReference Include="FsUnit.xUnit" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
+++ b/src/FSharp.Control.TaskSeq/FSharp.Control.TaskSeq.fsproj
@@ -57,7 +57,15 @@ Generates optimized IL code through resumable state machines, and comes with a c
   </ItemGroup>
 
   <ItemGroup>
-    <!-- maximal compatibility with minimal required FSharp.Core version for TaskSeq -->
-    <PackageReference Update="FSharp.Core" Version="6.0.1" />
+    <!--
+      Maximum compatibility with minimally required FSharp.Core version for TaskSeq
+      IMPORTANT: Leave this in! F# automatically adds an FSharp.Core reference if absent
+                 but it chooses the highest stable version by default (8.0+). This way, we
+                 stick to being most compatible.
+    -->
+    <PackageReference Update="FSharp.Core" Version="6.0.1">
+      <!-- if using "remove unused references", this prevents FSharp.Core from being shown in that list -->
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Merging dependabot PR's #252 and #251. They will auto-close after this is merged.

Also: added some explanation on why we do the `FSharp.Core.dll` versions the way we do (as in: lowest possible version w.r.t. backwards compatibility).