### PR TITLE
Modify task extensions to support backgroundTask

### DIFF
--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fs
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fs
@@ -14,8 +14,8 @@ open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 [<AutoOpen>]
 module TaskExtensions =
 
-    // Add asynchronous for loop to the 'task' computation builder
-    type Microsoft.FSharp.Control.TaskBuilder with
+    // Add asynchronous for loop to the 'task' and 'backgroundTask' computation builders
+    type TaskBuilderBase with
 
         /// Used by `For`. F# currently doesn't support `while!`, so this cannot be called directly from the task CE
         /// This code is mostly a copy of TaskSeq.WhileAsync.

--- a/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskExtensions.fsi
@@ -5,7 +5,7 @@ namespace FSharp.Control
 [<AutoOpen>]
 module TaskExtensions =
 
-    type TaskBuilder with
+    type TaskBuilderBase with
 
         /// <summary>
         /// Inside <see cref="task" />, iterate over all values of a <see cref="taskSeq" />.


### PR DESCRIPTION
I noticed the for-loop extension to the `task` CE doesn't work with `backgroundTask` because the code extends `TaskBuilder` instead of the more general `TaskBuilderBase`, from which both `TaskBuilder` and `BackgroundTaskBuilder` inherit.

This PR does the small change to support `backgroundTask` as well.