### PR TITLE
🔐 Set up trusted publishing for NuGet releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  #contents: write      # for peaceiris/actions-gh-pages
+  id-token: write      # for NuGet trusted publishing
+
 jobs:
   publish:
     name: Publish nuget (if new version)
@@ -24,13 +28,11 @@ jobs:
         # very important, since we use cmd scripts, the default is psh, and a bug prevents errorlevel to bubble
         shell: cmd
         run: ./build.cmd
-      - name: Nuget publish
-        # skip-duplicate ensures that the 409 error received when the package was already published,
-        # will just issue a warning and won't have the GH action fail.
-        # NUGET_PUBLISH_TOKEN_TASKSEQ is valid until approx. 11 Dec 2024 and will need to be updated by then:
-        # - log in to Nuget.org using 'abelbraaksma' admin account and then refresh the token in Nuget
-        # - copy the token
-        # - go to https://github.com/fsprojects/FSharp.Control.TaskSeq/settings/secrets/actions
-        # - select button "Add repository secret" or update the existing one under "Repository secrets"
-        # - rerun the job
-        run: dotnet nuget push packages\FSharp.Control.TaskSeq.*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_PUBLISH_TOKEN_TASKSEQ }} --skip-duplicate
+      - name: Obtain NuGet key
+        # this hash is v1.1.0
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544
+        id: login
+        with:
+            user: dsyme
+      - name: Publish NuGets (if this version not published before)
+        run: dotnet nuget push packages\FSharp.Control.TaskSeq.*.nupkg -s https://www.nuget.org/api/v2/package -k ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate


### PR DESCRIPTION
## Summary

- Replaces manual NuGet API key secret with **trusted publishing** via the `NuGet/login` action
- Adds `id-token: write` permission to the workflow to support OIDC-based authentication
- Removes the need to manually rotate and store the `NUGET_PUBLISH_TOKEN_TASKSEQ` secret
