### PR TITLE
[Repo Assist] ci: switch test-reporter workflow from windows-latest to ubuntu-latest

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -11,7 +11,7 @@ on:
       - completed
 jobs:
   test-report-release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@v2
       with:
@@ -21,7 +21,7 @@ jobs:
         reporter: dotnet-trx              # Format of test results
 
   test-report-debug:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@v2
       with:


### PR DESCRIPTION
The ci-report workflow only runs dorny/test-reporter, which downloads
test artifacts and posts check run results. This work is
platform-independent and does not require a Windows environment.

Switching to ubuntu-latest:
- Reduces CI job startup time (~1–2 min faster per PR)
- Reduces per-minute billing cost (Windows runners are ~2x more
  expensive than Linux runners)
- No functional difference: TRX files from the test jobs are just
  downloaded and parsed, not executed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
