### PR TITLE
[Repo Assist] eng: update GitHub Actions to latest major versions (bundle)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}
@@ -35,7 +35,7 @@ jobs:
     steps:
       # checkout the code
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
 
       # cache NuGet packages to avoid re-downloading on every run
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # checkout the code
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       # setup dotnet based on global.json
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v4
       # cache NuGet packages to avoid re-downloading on every run
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}
@@ -38,7 +38,7 @@ jobs:
     steps:
       # checkout the code
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       # setup dotnet based on global.json
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-dotnet@v4
       # cache NuGet packages to avoid re-downloading on every run
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # checkout the code
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       # setup dotnet based on global.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the code
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -19,7 +19,7 @@ jobs:
 
       # cache NuGet packages to avoid re-downloading on every run
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}
@@ -47,7 +47,7 @@ jobs:
     steps:
       # checkout the code
       - name: checkout-code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
 
       # cache NuGet packages to avoid re-downloading on every run
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}


### PR DESCRIPTION
- actions/checkout: v5 → v6 (all workflow files)
- actions/cache: v4 → v5 (build.yaml, test.yaml, main.yaml)

Supersedes Dependabot PR #323 (actions/cache bump).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
