### PR TITLE
[Repo Assist] ci: align docs.yaml action versions with rest of workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', 'global.json') }}


### PR DESCRIPTION
Update docs.yaml to match the action versions used by every other
workflow in this repo:
- actions/checkout@v4 -> actions/checkout@v6
- actions/cache@v4   -> actions/cache@v5

Closes #361

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
