### PR TITLE
[Repo Assist] ci: align action versions in docs workflow and add NuGet cache to publish workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', 'global.json') }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,13 @@ jobs:
       # setup dotnet based on global.json
       - name: setup-dotnet
         uses: actions/setup-dotnet@v4
+      # cache NuGet packages to avoid re-downloading on every run
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}
+          restore-keys: nuget-${{ runner.os }}-
       # build it, test it, pack it, publish it
       - name: Run dotnet build (release, for nuget)
         # see issue #105 and #243


### PR DESCRIPTION
- docs.yaml: bump actions/checkout from v4 to v6 (matches other workflows)
- docs.yaml: bump actions/cache from v4 to v5 (matches other workflows)
- publish.yaml: add missing NuGet cache step (all other workflows cache NuGet packages)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
