### PR TITLE
feature/choose-value-option

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -2,7 +2,7 @@
 Release notes:
 
 1.1.0
-    - adds TaskSeq.chooseV, TaskSeq.chooseVAsync, #167
+    - adds TaskSeq.chooseV, TaskSeq.chooseVAsync, #385
 
 1.0.0
     - adds taskSeqDynamic computation expression and TaskSeqDynamic/TaskSeqDynamicInfo types for dynamic (FSI-compatible) resumable code, fixing issue where taskSeq would raise NotImplementedException in F# Interactive, #246

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,6 +1,9 @@
 
 Release notes:
 
+1.1.0
+    - adds TaskSeq.chooseV, TaskSeq.chooseVAsync, #167
+
 1.0.0
     - adds taskSeqDynamic computation expression and TaskSeqDynamic/TaskSeqDynamicInfo types for dynamic (FSI-compatible) resumable code, fixing issue where taskSeq would raise NotImplementedException in F# Interactive, #246
     - perf: TaskSeq.chunkBy and chunkByAsync reuse the ResizeArray buffer between chunks, reducing allocations on sequences with many chunk boundaries

--- a/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
+++ b/src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="TaskSeq.Append.Tests.fs" />
     <Compile Include="TaskSeq.Cast.Tests.fs" />
     <Compile Include="TaskSeq.Choose.Tests.fs" />
+    <Compile Include="TaskSeq.ChooseV.Tests.fs" />
     <Compile Include="TaskSeq.Collect.Tests.fs" />
     <Compile Include="TaskSeq.Concat.Tests.fs" />
     <Compile Include="TaskSeq.Contains.Tests.fs" />

--- a/src/FSharp.Control.TaskSeq.Test/TaskSeq.ChooseV.Tests.fs
+++ b/src/FSharp.Control.TaskSeq.Test/TaskSeq.ChooseV.Tests.fs
@@ -1,0 +1,246 @@
+module TaskSeq.Tests.ChooseV
+
+open System
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Control
+
+//
+// TaskSeq.chooseV
+// TaskSeq.chooseVAsync
+//
+
+module EmptySeq =
+    [<Fact>]
+    let ``Null source is invalid`` () =
+        assertNullArg
+        <| fun () -> TaskSeq.chooseV (fun _ -> ValueNone) null
+
+        assertNullArg
+        <| fun () -> TaskSeq.chooseVAsync (fun _ -> Task.fromResult ValueNone) null
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-chooseV`` variant = task {
+        let! empty =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.chooseV (fun _ -> ValueSome 42)
+            |> TaskSeq.toListAsync
+
+        List.isEmpty empty |> should be True
+    }
+
+    [<Theory; ClassData(typeof<TestEmptyVariants>)>]
+    let ``TaskSeq-chooseVAsync`` variant = task {
+        let! empty =
+            Gen.getEmptyVariant variant
+            |> TaskSeq.chooseVAsync (fun _ -> task { return ValueSome 42 })
+            |> TaskSeq.toListAsync
+
+        List.isEmpty empty |> should be True
+    }
+
+module Immutable =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-chooseV can convert and filter`` variant = task {
+        let chooser number =
+            if number <= 5 then
+                ValueSome(char number + '@')
+            else
+                ValueNone
+
+        let ts = Gen.getSeqImmutable variant
+
+        let! letters1 = TaskSeq.chooseV chooser ts |> TaskSeq.toArrayAsync
+        let! letters2 = TaskSeq.chooseV chooser ts |> TaskSeq.toArrayAsync
+
+        String letters1 |> should equal "ABCDE"
+        String letters2 |> should equal "ABCDE"
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-chooseVAsync can convert and filter`` variant = task {
+        let chooser number = task {
+            return
+                if number <= 5 then
+                    ValueSome(char number + '@')
+                else
+                    ValueNone
+        }
+
+        let ts = Gen.getSeqImmutable variant
+
+        let! letters1 = TaskSeq.chooseVAsync chooser ts |> TaskSeq.toArrayAsync
+        let! letters2 = TaskSeq.chooseVAsync chooser ts |> TaskSeq.toArrayAsync
+
+        String letters1 |> should equal "ABCDE"
+        String letters2 |> should equal "ABCDE"
+    }
+
+module Immutable2 =
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-chooseV returns all when chooser always returns ValueSome`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+        let! xs = ts |> TaskSeq.chooseV ValueSome |> TaskSeq.toArrayAsync
+        xs |> should equal [| 1..10 |]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-chooseVAsync returns all when chooser always returns ValueSome`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        let! xs =
+            ts
+            |> TaskSeq.chooseVAsync (fun x -> task { return ValueSome x })
+            |> TaskSeq.toArrayAsync
+
+        xs |> should equal [| 1..10 |]
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-chooseV returns empty when chooser always returns ValueNone`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        do! ts |> TaskSeq.chooseV (fun _ -> ValueNone) |> verifyEmpty
+    }
+
+    [<Theory; ClassData(typeof<TestImmTaskSeq>)>]
+    let ``TaskSeq-chooseVAsync returns empty when chooser always returns ValueNone`` variant = task {
+        let ts = Gen.getSeqImmutable variant
+
+        do!
+            ts
+            |> TaskSeq.chooseVAsync (fun _ -> task { return ValueNone })
+            |> verifyEmpty
+    }
+
+    [<Fact>]
+    let ``TaskSeq-chooseV with singleton sequence and ValueSome chooser returns singleton`` () = task {
+        let! xs =
+            taskSeq { yield 42 }
+            |> TaskSeq.chooseV (fun x -> ValueSome(x * 2))
+            |> TaskSeq.toListAsync
+
+        xs |> should equal [ 84 ]
+    }
+
+    [<Fact>]
+    let ``TaskSeq-chooseV with singleton sequence and ValueNone chooser returns empty`` () =
+        taskSeq { yield 42 }
+        |> TaskSeq.chooseV (fun _ -> ValueNone)
+        |> verifyEmpty
+
+    [<Fact>]
+    let ``TaskSeq-chooseV can change the element type`` () = task {
+        // choose maps int -> string voption, verifying type-changing behavior
+        let chooser n =
+            if n % 2 = 0 then
+                ValueSome(sprintf "even-%d" n)
+            else
+                ValueNone
+
+        let! xs =
+            taskSeq { yield! [ 1..6 ] }
+            |> TaskSeq.chooseV chooser
+            |> TaskSeq.toListAsync
+
+        xs |> should equal [ "even-2"; "even-4"; "even-6" ]
+    }
+
+    [<Fact>]
+    let ``TaskSeq-chooseVAsync can change the element type`` () = task {
+        let chooser n = task {
+            return
+                if n % 2 = 0 then
+                    ValueSome(sprintf "even-%d" n)
+                else
+                    ValueNone
+        }
+
+        let! xs =
+            taskSeq { yield! [ 1..6 ] }
+            |> TaskSeq.chooseVAsync chooser
+            |> TaskSeq.toListAsync
+
+        xs |> should equal [ "even-2"; "even-4"; "even-6" ]
+    }
+
+module SideEffects =
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-chooseV applied multiple times`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let chooser x number =
+            if number <= x then
+                ValueSome(char number + '@')
+            else
+                ValueNone
+
+        let! lettersA = ts |> TaskSeq.chooseV (chooser 5) |> TaskSeq.toArrayAsync
+        let! lettersK = ts |> TaskSeq.chooseV (chooser 15) |> TaskSeq.toArrayAsync
+        let! lettersU = ts |> TaskSeq.chooseV (chooser 25) |> TaskSeq.toArrayAsync
+
+        String lettersA |> should equal "ABCDE"
+        String lettersK |> should equal "KLMNO"
+        String lettersU |> should equal "UVWXY"
+    }
+
+    [<Theory; ClassData(typeof<TestSideEffectTaskSeq>)>]
+    let ``TaskSeq-chooseVAsync applied multiple times`` variant = task {
+        let ts = Gen.getSeqWithSideEffect variant
+
+        let chooser x number = task {
+            return
+                if number <= x then
+                    ValueSome(char number + '@')
+                else
+                    ValueNone
+        }
+
+        let! lettersA = TaskSeq.chooseVAsync (chooser 5) ts |> TaskSeq.toArrayAsync
+        let! lettersK = TaskSeq.chooseVAsync (chooser 15) ts |> TaskSeq.toArrayAsync
+        let! lettersU = TaskSeq.chooseVAsync (chooser 25) ts |> TaskSeq.toArrayAsync
+
+        String lettersA |> should equal "ABCDE"
+        String lettersK |> should equal "KLMNO"
+        String lettersU |> should equal "UVWXY"
+    }
+
+    [<Fact>]
+    let ``TaskSeq-chooseV evaluates each source element exactly once`` () = task {
+        let mutable count = 0
+
+        let ts = taskSeq {
+            for i in 1..5 do
+                count <- count + 1
+                yield i
+        }
+
+        let! xs =
+            ts
+            |> TaskSeq.chooseV (fun x -> if x < 3 then ValueSome x else ValueNone)
+            |> TaskSeq.toListAsync
+
+        count |> should equal 5 // all 5 elements were visited
+        xs |> should equal [ 1; 2 ]
+    }
+
+    [<Fact>]
+    let ``TaskSeq-chooseVAsync evaluates each source element exactly once`` () = task {
+        let mutable count = 0
+
+        let ts = taskSeq {
+            for i in 1..5 do
+                count <- count + 1
+                yield i
+        }
+
+        let! xs =
+            ts
+            |> TaskSeq.chooseVAsync (fun x -> task { return if x < 3 then ValueSome x else ValueNone })
+            |> TaskSeq.toListAsync
+
+        count |> should equal 5
+        xs |> should equal [ 1; 2 ]
+    }

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fs
@@ -441,7 +441,9 @@ type TaskSeq private () =
         }
 
     static member choose chooser source = Internal.choose (TryPick chooser) source
+    static member chooseV chooser source = Internal.chooseV (TryPickV chooser) source
     static member chooseAsync chooser source = Internal.choose (TryPickAsync chooser) source
+    static member chooseVAsync chooser source = Internal.chooseV (TryPickVAsync chooser) source
 
     static member filter predicate source = Internal.filter (Predicate predicate) source
     static member filterAsync predicate source = Internal.filter (PredicateAsync predicate) source

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -1012,6 +1012,18 @@ type TaskSeq =
     static member choose: chooser: ('T -> 'U option) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
+    /// Applies the given function <paramref name="chooser" /> to each element of the task sequence. Returns
+    /// a sequence comprised of the results where the function returns <see cref="ValueSome(x)" />.
+    /// If <paramref name="chooser" /> is asynchronous, consider using <see cref="TaskSeq.chooseAsync" />.
+    /// </summary>
+    ///
+    /// <param name="chooser">A function to transform items of type <paramref name="'T" /> into value options of type <paramref name="'U" />.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The resulting task sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member chooseV: chooser: ('T -> 'U voption) -> source: TaskSeq<'T> -> TaskSeq<'U>
+
+    /// <summary>
     /// Applies the given asynchronous function <paramref name="chooser" /> to each element of the task sequence.
     /// Returns a sequence comprised of the results where the function returns a <see cref="task" /> result
     /// of <see cref="Some(x)" />.
@@ -1023,6 +1035,19 @@ type TaskSeq =
     /// <returns>The resulting task sequence.</returns>
     /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
     static member chooseAsync: chooser: ('T -> #Task<'U option>) -> source: TaskSeq<'T> -> TaskSeq<'U>
+
+    /// <summary>
+    /// Applies the given asynchronous function <paramref name="chooser" /> to each element of the task sequence.
+    /// Returns a sequence comprised of the results where the function returns a <see cref="task" /> result
+    /// of <see cref="ValueSome(x)" />.
+    /// If <paramref name="chooser" /> is synchronous, consider using <see cref="TaskSeq.chooseV" />.
+    /// </summary>
+    ///
+    /// <param name="chooser">An asynchronous function to transform items of type <paramref name="'T" /> into value options of type <paramref name="'U" />.</param>
+    /// <param name="source">The input task sequence.</param>
+    /// <returns>The resulting task sequence.</returns>
+    /// <exception cref="T:ArgumentNullException">Thrown when the input task sequence is null.</exception>
+    static member chooseVAsync: chooser: ('T -> #Task<'U voption>) -> source: TaskSeq<'T> -> TaskSeq<'U>
 
     /// <summary>
     /// Returns a new task sequence containing only the elements of the collection

--- a/src/FSharp.Control.TaskSeq/TaskSeq.fsi
+++ b/src/FSharp.Control.TaskSeq/TaskSeq.fsi
@@ -1014,7 +1014,7 @@ type TaskSeq =
     /// <summary>
     /// Applies the given function <paramref name="chooser" /> to each element of the task sequence. Returns
     /// a sequence comprised of the results where the function returns <see cref="ValueSome(x)" />.
-    /// If <paramref name="chooser" /> is asynchronous, consider using <see cref="TaskSeq.chooseAsync" />.
+    /// If <paramref name="chooser" /> is asynchronous, consider using <see cref="TaskSeq.chooseVAsync" />.
     /// </summary>
     ///
     /// <param name="chooser">A function to transform items of type <paramref name="'T" /> into value options of type <paramref name="'U" />.</param>

--- a/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
+++ b/src/FSharp.Control.TaskSeq/TaskSeqInternal.fs
@@ -40,6 +40,11 @@ type internal ChooserAction<'T, 'U, 'TaskOption when 'TaskOption :> Task<'U opti
     | TryPickAsync of async_try_pick: ('T -> 'TaskOption)
 
 [<Struct>]
+type internal ChooserVAction<'T, 'U, 'TaskValueOption when 'TaskValueOption :> Task<'U voption>> =
+    | TryPickV of try_pickv: ('T -> 'U voption)
+    | TryPickVAsync of async_try_pickv: ('T -> 'TaskValueOption)
+
+[<Struct>]
 type internal PredicateAction<'T, 'TaskBool when 'TaskBool :> Task<bool>> =
     | Predicate of try_filter: ('T -> bool)
     | PredicateAsync of async_try_filter: ('T -> 'TaskBool)
@@ -1053,6 +1058,25 @@ module internal TaskSeqInternal =
                     match! picker item with
                     | Some value -> yield value
                     | None -> ()
+        }
+
+    let chooseV chooser (source: TaskSeq<_>) =
+        checkNonNull (nameof source) source
+
+        taskSeq {
+
+            match chooser with
+            | TryPickV picker ->
+                for item in source do
+                    match picker item with
+                    | ValueSome value -> yield value
+                    | ValueNone -> ()
+
+            | TryPickVAsync picker ->
+                for item in source do
+                    match! picker item with
+                    | ValueSome value -> yield value
+                    | ValueNone -> ()
         }
 
     let filter predicate (source: TaskSeq<_>) =


### PR DESCRIPTION
 * Adds `ValueOption` variants for `choose`: `TaskSeq.chooseV`, `TaskSeq.chooseVAsync`
 * These variants can avoid allocations for better performance in some scenarios
 * The tests are a modified copy of those for `choose`
 * I was unsure about naming convention; happy to change it with some guidance
 * I will make a follow up PR for `TaskSeq.tryPick`, `TaskSeq.pick` etc. if desired