### PR TITLE
[Repo Assist] eng: bump SDK pin in global.json from 10.0.102 to 10.0.105

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.102",
+    "version": "10.0.105",
     "rollForward": "minor"
   }
 }


### PR DESCRIPTION
The .NET 10 SDK patch 10.0.105 is now the latest available version on the runners (rollForward:minor already picks it up; this keeps global.json in sync with the actual runtime used).