### PR TITLE
[Repo Assist] eng: add Linux release test job to main.yaml CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,3 +65,35 @@ jobs:
           # this path glob pattern requires forward slashes!
           path: ./src/FSharp.Control.TaskSeq.Test/TestResults/test-results-release.trx
           reporter: dotnet-trx
+
+  test-release-linux:
+    name: Test Release Build (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout-code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setup-dotnet
+        uses: actions/setup-dotnet@v4
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.fsproj', '**/*.csproj', 'global.json') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      # build.cmd is Windows-only; run dotnet test directly on Linux
+      - name: Run dotnet test - release (Linux)
+        run: dotnet test src/FSharp.Control.TaskSeq.Test/FSharp.Control.TaskSeq.Test.fsproj -c Release --blame-hang-timeout 60000ms --logger "console;verbosity=detailed" --logger "trx;LogFileName=test-results-release-linux.trx"
+
+      - name: Publish test results - release (Linux)
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Report release tests (Linux)
+          # this path glob pattern requires forward slashes!
+          path: ./src/FSharp.Control.TaskSeq.Test/TestResults/test-results-release-linux.trx
+          reporter: dotnet-trx


### PR DESCRIPTION
The PR check workflow (test.yaml) already runs tests on Linux, but the
main-branch workflow (main.yaml) only tested on Windows. This gap means
Linux-specific failures on merged code would not be caught immediately.

Add a test-release-linux job mirroring the one in test.yaml:
- runs on ubuntu-latest
- calls dotnet test directly (build.cmd is Windows-only)
- uses dorny/test-reporter@v2 for inline result reporting

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
